### PR TITLE
Use single snapshot for burn rate

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/features/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/home/ui/HomeFragment.kt
@@ -26,6 +26,7 @@ import com.google.android.material.chip.Chip
 import com.google.android.material.chip.ChipGroup
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import java.text.SimpleDateFormat
 import java.util.*
 import java.util.concurrent.TimeUnit
@@ -194,23 +195,12 @@ class HomeFragment : Fragment() {
 
     private suspend fun calculateAverageBurnRate(): Double {
         val weekStart = System.currentTimeMillis() - (7 * 24 * 60 * 60 * 1000)
-        val activities = database.activityDao().getAllActivities()
-        
-        var totalBurn = 0.0
-        var activityCount = 0
-        
-        activities.collect { activityList ->
-            val weeklyActivities = activityList.filter { 
-                it.date >= weekStart && it.energy < 0 
-            }
-            
-            if (weeklyActivities.isNotEmpty()) {
-                totalBurn = weeklyActivities.sumOf { abs(it.energy.toDouble()) }
-                activityCount = weeklyActivities.size
-            }
-        }
-        
-        return if (activityCount > 0) totalBurn / activityCount else 2.0
+        val activityList = database.activityDao().getAllActivities().first()
+
+        val weeklyActivities = activityList.filter { it.date >= weekStart && it.energy < 0 }
+        val totalBurn = weeklyActivities.sumOf { abs(it.energy.toDouble()) }
+
+        return if (weeklyActivities.isNotEmpty()) totalBurn / weeklyActivities.size else 2.0
     }
 
     private fun calculateWeeklyForecast() {


### PR DESCRIPTION
## Summary
- Replace Flow collect with first() to retrieve a single snapshot when computing burn rate
- Calculate weekly burn rate directly from snapshot and remove mutable state

## Testing
- `./gradlew test` *(fails: Build was configured to prefer settings repositories over project repositories but repository 'Google' was added)*

------
https://chatgpt.com/codex/tasks/task_e_688e01817d9c83248e0ee26fbef04ee0