### PR TITLE
Specify UTF-8 for backup checksum

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/data/repository/DataRepository.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/data/repository/DataRepository.kt
@@ -9,6 +9,7 @@ import com.google.gson.Gson
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import java.security.MessageDigest
+import java.nio.charset.StandardCharsets
 import java.util.UUID
 
 class DataRepository private constructor(
@@ -143,9 +144,16 @@ class DataRepository private constructor(
     }
     
     private fun generateChecksum(activities: List<ActivityEntity>, auditLogs: List<AuditLogEntity>): String {
-        val data = gson.toJson(activities) + gson.toJson(auditLogs)
         val digest = MessageDigest.getInstance("SHA-256")
-        return digest.digest(data.toByteArray()).joinToString("") { "%02x".format(it) }
+        val activitiesBytes = gson
+            .toJson(activities)
+            .toByteArray(StandardCharsets.UTF_8)
+        val auditLogsBytes = gson
+            .toJson(auditLogs)
+            .toByteArray(StandardCharsets.UTF_8)
+        digest.update(activitiesBytes)
+        digest.update(auditLogsBytes)
+        return digest.digest().joinToString("") { "%02x".format(it) }
     }
     
     // Cleanup operations

--- a/app/src/test/java/com/example/socialbatterymanager/data/repository/DataRepositoryChecksumTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/data/repository/DataRepositoryChecksumTest.kt
@@ -1,0 +1,103 @@
+package com.example.socialbatterymanager.data.repository
+
+import com.example.socialbatterymanager.data.database.*
+import com.example.socialbatterymanager.data.model.ActivityEntity
+import com.example.socialbatterymanager.data.model.AuditLogEntity
+import com.google.gson.Gson
+import java.nio.charset.Charset
+import java.util.Locale
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+private class FakeAppDatabase : AppDatabase() {
+    override fun activityDao(): ActivityDao = throw NotImplementedError()
+    override fun auditLogDao(): AuditLogDao = throw NotImplementedError()
+    override fun backupMetadataDao(): BackupMetadataDao = throw NotImplementedError()
+    override fun energyLogDao(): EnergyLogDao = throw NotImplementedError()
+    override fun userDao(): UserDao = throw NotImplementedError()
+    override fun personDao(): PersonDao = throw NotImplementedError()
+    override fun calendarEventDao(): CalendarEventDao = throw NotImplementedError()
+    override fun notificationDao(): NotificationDao = throw NotImplementedError()
+}
+
+class DataRepositoryChecksumTest {
+    private fun createRepository(): DataRepository {
+        val constructor = DataRepository::class.java.getDeclaredConstructor(AppDatabase::class.java, Gson::class.java)
+        constructor.isAccessible = true
+        return constructor.newInstance(FakeAppDatabase(), Gson())
+    }
+
+    private fun invokeChecksum(
+        repo: DataRepository,
+        activities: List<ActivityEntity>,
+        auditLogs: List<AuditLogEntity>
+    ): String {
+        val method = DataRepository::class.java.getDeclaredMethod(
+            "generateChecksum",
+            List::class.java,
+            List::class.java
+        )
+        method.isAccessible = true
+        return method.invoke(repo, activities, auditLogs) as String
+    }
+
+    @Test
+    fun checksum_isConsistentAcrossLocales() {
+        val repo = createRepository()
+        val activities = listOf(
+            ActivityEntity(
+                name = "Ångström",
+                type = "Social",
+                energy = 1,
+                people = "Før",
+                mood = "Ok",
+                notes = "ñandú",
+                date = 0
+            )
+        )
+        val auditLogs = emptyList<AuditLogEntity>()
+
+        val defaultLocale = Locale.getDefault()
+        Locale.setDefault(Locale.US)
+        val checksumUs = invokeChecksum(repo, activities, auditLogs)
+
+        Locale.setDefault(Locale("tr", "TR"))
+        val checksumTr = invokeChecksum(repo, activities, auditLogs)
+        Locale.setDefault(defaultLocale)
+
+        assertEquals(checksumUs, checksumTr)
+    }
+
+    @Test
+    fun checksum_isConsistentAcrossEncodings() {
+        val repo = createRepository()
+        val activities = listOf(
+            ActivityEntity(
+                name = "Ångström",
+                type = "Social",
+                energy = 1,
+                people = "Før",
+                mood = "Ok",
+                notes = "ñandú",
+                date = 0
+            )
+        )
+        val auditLogs = emptyList<AuditLogEntity>()
+
+        val baseline = invokeChecksum(repo, activities, auditLogs)
+
+        val originalCharset = Charset.defaultCharset()
+        val charsetField = Charset::class.java.getDeclaredField("defaultCharset")
+        charsetField.isAccessible = true
+        try {
+            System.setProperty("file.encoding", "ISO-8859-1")
+            charsetField.set(null, null)
+            val changed = invokeChecksum(repo, activities, auditLogs)
+            assertEquals(baseline, changed)
+        } finally {
+            System.setProperty("file.encoding", originalCharset.name())
+            charsetField.set(null, null)
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Hash backup data using UTF-8 encoded bytes for deterministic checksums
- Add tests to ensure checksum generation is stable across locales and charset settings

## Testing
- `./gradlew ktlintCheck test` *(fails: Build was configured to prefer settings repositories over project repositories but repository 'Google' was added by build file)*

------
https://chatgpt.com/codex/tasks/task_e_688e0182997c8324a5d9f78f55899b8e