### PR TITLE
refactor: streamline theme application

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/MainActivity.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/MainActivity.kt
@@ -10,6 +10,8 @@ import com.example.socialbatterymanager.shared.preferences.PreferencesManager
 import com.example.socialbatterymanager.sync.SyncManager
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 
 class MainActivity : AppCompatActivity() {
     
@@ -23,8 +25,20 @@ class MainActivity : AppCompatActivity() {
         preferencesManager = PreferencesManager(this)
         syncManager = SyncManager(this)
         
-        // Apply theme before setting content
-        applyTheme()
+        // Set initial theme before inflating the layout
+        runBlocking {
+            when (preferencesManager.themeFlow.first()) {
+                PreferencesManager.THEME_LIGHT -> {
+                    AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+                }
+                PreferencesManager.THEME_DARK -> {
+                    AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
+                }
+                PreferencesManager.THEME_SYSTEM -> {
+                    AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
+                }
+            }
+        }
         
         setContentView(R.layout.activity_main) // Fixed typo
 
@@ -41,7 +55,7 @@ class MainActivity : AppCompatActivity() {
         // Initialize sync
         initializeSync()
         
-        // Observe theme changes
+        // Observe theme changes for runtime updates
         observeThemeChanges()
     }
     
@@ -68,24 +82,6 @@ class MainActivity : AppCompatActivity() {
                     // User hasn't completed onboarding, navigate to onboarding if not already there
                     if (navController.currentDestination?.id != R.id.onboardingFragment) {
                         navController.navigate(R.id.onboardingFragment)
-                    }
-                }
-            }
-        }
-    }
-    
-    private fun applyTheme() {
-        lifecycleScope.launch {
-            preferencesManager.themeFlow.collect { theme ->
-                when (theme) {
-                    PreferencesManager.THEME_LIGHT -> {
-                        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
-                    }
-                    PreferencesManager.THEME_DARK -> {
-                        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
-                    }
-                    PreferencesManager.THEME_SYSTEM -> {
-                        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- initialize theme once using `themeFlow.first` before content view inflation
- remove redundant `applyTheme` method and clarify runtime theme observation comment

## Testing
- `./gradlew test` *(fails: Build was configured to prefer settings repositories over project repositories but repository 'Google' was added by build file build.gradle.kts)*

------
https://chatgpt.com/codex/tasks/task_e_688e018332a88324829306492316d1b5