### PR TITLE
Handle DataStore errors in PreferencesManager flows

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/shared/preferences/PreferencesManager.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/shared/preferences/PreferencesManager.kt
@@ -9,11 +9,20 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "app_preferences")
 
-class PreferencesManager(private val context: Context) {
+/**
+ * Handles persistence of simple user preferences.
+ *
+ * Each exposed [Flow] emits a sensible default when the underlying DataStore
+ * encounters an error, ensuring callers always receive a value.
+ */
+class PreferencesManager(private val dataStore: DataStore<Preferences>) {
+
+    constructor(context: Context) : this(context.dataStore)
     
     companion object {
         private val THEME_KEY = stringPreferencesKey("theme_preference")
@@ -28,68 +37,92 @@ class PreferencesManager(private val context: Context) {
         const val THEME_SYSTEM = "system"
     }
     
-    val themeFlow: Flow<String> = context.dataStore.data
+    /**
+     * Emits the stored theme or [THEME_SYSTEM] if unavailable or on read error.
+     */
+    val themeFlow: Flow<String> = dataStore.data
         .map { preferences ->
             preferences[THEME_KEY] ?: THEME_SYSTEM
         }
+        .catch { emit(THEME_SYSTEM) }
     
-    val onboardingCompletedFlow: Flow<Boolean> = context.dataStore.data
+    /**
+     * Emits whether onboarding is completed. Defaults to `false` on errors.
+     */
+    val onboardingCompletedFlow: Flow<Boolean> = dataStore.data
         .map { preferences ->
             preferences[ONBOARDING_COMPLETED_KEY] ?: false
         }
+        .catch { emit(false) }
     
-    val biometricEnabledFlow: Flow<Boolean> = context.dataStore.data
+    /**
+     * Emits the biometric preference, defaulting to `false` when reading fails.
+     */
+    val biometricEnabledFlow: Flow<Boolean> = dataStore.data
         .map { preferences ->
             preferences[BIOMETRIC_ENABLED_KEY] ?: false
         }
+        .catch { emit(false) }
     
-    val notificationsEnabledFlow: Flow<Boolean> = context.dataStore.data
+    /**
+     * Emits notification setting, defaulting to `true` on errors.
+     */
+    val notificationsEnabledFlow: Flow<Boolean> = dataStore.data
         .map { preferences ->
             preferences[NOTIFICATIONS_ENABLED_KEY] ?: true
         }
+        .catch { emit(true) }
     
-    val syncEnabledFlow: Flow<Boolean> = context.dataStore.data
+    /**
+     * Emits sync setting, defaulting to `true` on errors.
+     */
+    val syncEnabledFlow: Flow<Boolean> = dataStore.data
         .map { preferences ->
             preferences[SYNC_ENABLED_KEY] ?: true
         }
+        .catch { emit(true) }
     
-    val batteryNotificationThresholdFlow: Flow<Int> = context.dataStore.data
+    /**
+     * Emits notification threshold, defaulting to `25` on errors.
+     */
+    val batteryNotificationThresholdFlow: Flow<Int> = dataStore.data
         .map { preferences ->
             preferences[BATTERY_NOTIFICATION_THRESHOLD_KEY] ?: 25
         }
+        .catch { emit(25) }
     
     suspend fun setTheme(theme: String) {
-        context.dataStore.edit { preferences ->
+        dataStore.edit { preferences ->
             preferences[THEME_KEY] = theme
         }
     }
     
     suspend fun setOnboardingCompleted(completed: Boolean) {
-        context.dataStore.edit { preferences ->
+        dataStore.edit { preferences ->
             preferences[ONBOARDING_COMPLETED_KEY] = completed
         }
     }
     
     suspend fun setBiometricEnabled(enabled: Boolean) {
-        context.dataStore.edit { preferences ->
+        dataStore.edit { preferences ->
             preferences[BIOMETRIC_ENABLED_KEY] = enabled
         }
     }
     
     suspend fun setNotificationsEnabled(enabled: Boolean) {
-        context.dataStore.edit { preferences ->
+        dataStore.edit { preferences ->
             preferences[NOTIFICATIONS_ENABLED_KEY] = enabled
         }
     }
     
     suspend fun setSyncEnabled(enabled: Boolean) {
-        context.dataStore.edit { preferences ->
+        dataStore.edit { preferences ->
             preferences[SYNC_ENABLED_KEY] = enabled
         }
     }
     
     suspend fun setBatteryNotificationThreshold(threshold: Int) {
-        context.dataStore.edit { preferences ->
+        dataStore.edit { preferences ->
             preferences[BATTERY_NOTIFICATION_THRESHOLD_KEY] = threshold
         }
     }

--- a/app/src/test/java/com/example/socialbatterymanager/shared/preferences/PreferencesManagerTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/shared/preferences/PreferencesManagerTest.kt
@@ -1,0 +1,55 @@
+package com.example.socialbatterymanager.shared.preferences
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+
+private class FailingDataStore : DataStore<Preferences> {
+    override val data: Flow<Preferences> = flow { throw IOException("Test failure") }
+    override suspend fun updateData(transform: suspend (t: Preferences) -> Preferences): Preferences {
+        throw UnsupportedOperationException()
+    }
+}
+
+class PreferencesManagerTest {
+    private val manager = PreferencesManager(FailingDataStore())
+
+    @Test
+    fun themeFlow_emitsDefaultOnError() = runBlocking {
+        assertEquals(PreferencesManager.THEME_SYSTEM, manager.themeFlow.first())
+    }
+
+    @Test
+    fun onboardingCompletedFlow_emitsDefaultOnError() = runBlocking {
+        assertFalse(manager.onboardingCompletedFlow.first())
+    }
+
+    @Test
+    fun biometricEnabledFlow_emitsDefaultOnError() = runBlocking {
+        assertFalse(manager.biometricEnabledFlow.first())
+    }
+
+    @Test
+    fun notificationsEnabledFlow_emitsDefaultOnError() = runBlocking {
+        assertTrue(manager.notificationsEnabledFlow.first())
+    }
+
+    @Test
+    fun syncEnabledFlow_emitsDefaultOnError() = runBlocking {
+        assertTrue(manager.syncEnabledFlow.first())
+    }
+
+    @Test
+    fun batteryNotificationThresholdFlow_emitsDefaultOnError() = runBlocking {
+        assertEquals(25, manager.batteryNotificationThresholdFlow.first())
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure PreferencesManager flows recover from DataStore failures by emitting defaults
- document behavior and add unit tests for default emissions

## Testing
- `./gradlew test` *(fails: Build was configured to prefer settings repositories over project repositories but repository 'Google' was added by build file 'build.gradle.kts')*

------
https://chatgpt.com/codex/tasks/task_e_688e01846d408324a0adfa48b7af16a6