### PR TITLE
Refactor UI messages to string resources

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/features/auth/ui/LoginFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/auth/ui/LoginFragment.kt
@@ -74,7 +74,7 @@ class LoginFragment : Fragment() {
             if (email.isNotEmpty() && password.isNotEmpty()) {
                 userViewModel.signInWithEmailAndPassword(email, password)
             } else {
-                Toast.makeText(context, "Please enter email and password", Toast.LENGTH_SHORT).show()
+                Toast.makeText(context, getString(R.string.enter_email_password), Toast.LENGTH_SHORT).show()
             }
         }
         
@@ -85,7 +85,7 @@ class LoginFragment : Fragment() {
             if (email.isNotEmpty() && password.isNotEmpty()) {
                 userViewModel.signUpWithEmailAndPassword(email, password)
             } else {
-                Toast.makeText(context, "Please enter email and password", Toast.LENGTH_SHORT).show()
+                Toast.makeText(context, getString(R.string.enter_email_password), Toast.LENGTH_SHORT).show()
             }
         }
         
@@ -133,7 +133,7 @@ class LoginFragment : Fragment() {
                 val account = task.getResult(ApiException::class.java)!!
                 userViewModel.signInWithGoogle(account.idToken!!)
             } catch (e: ApiException) {
-                Toast.makeText(context, "Google sign in failed: ${e.message}", Toast.LENGTH_SHORT).show()
+                Toast.makeText(context, getString(R.string.google_sign_in_failed, e.message), Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/app/src/main/java/com/example/socialbatterymanager/features/profile/ui/ProfileFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/profile/ui/ProfileFragment.kt
@@ -97,7 +97,7 @@ class ProfileFragment : Fragment() {
         if (granted) {
             showImageSourceDialog()
         } else {
-            Toast.makeText(requireContext(), "Permission denied", Toast.LENGTH_SHORT).show()
+            Toast.makeText(requireContext(), getString(R.string.permission_denied), Toast.LENGTH_SHORT).show()
         }
     }
 
@@ -165,7 +165,7 @@ class ProfileFragment : Fragment() {
 
         capacitySeekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
-                capacityText.text = "$progress%"
+                capacityText.text = getString(R.string.percent_format, progress)
             }
             override fun onStartTrackingTouch(seekBar: SeekBar?) {}
             override fun onStopTrackingTouch(seekBar: SeekBar?) {}
@@ -173,7 +173,7 @@ class ProfileFragment : Fragment() {
 
         warningSeekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
-                warningText.text = "$progress%"
+                warningText.text = getString(R.string.percent_format, progress)
             }
             override fun onStartTrackingTouch(seekBar: SeekBar?) {}
             override fun onStopTrackingTouch(seekBar: SeekBar?) {}
@@ -189,7 +189,7 @@ class ProfileFragment : Fragment() {
                 showImageSourceDialog()
             }
             shouldShowRequestPermissionRationale(Manifest.permission.READ_EXTERNAL_STORAGE) -> {
-                Toast.makeText(requireContext(), "Permission needed to access photos", Toast.LENGTH_LONG).show()
+                Toast.makeText(requireContext(), getString(R.string.permission_access_photos), Toast.LENGTH_LONG).show()
                 permissionLauncher.launch(Manifest.permission.READ_EXTERNAL_STORAGE)
             }
             else -> {
@@ -199,9 +199,13 @@ class ProfileFragment : Fragment() {
     }
 
     private fun showImageSourceDialog() {
-        val options = arrayOf("Choose from Gallery", "Take Photo", "Cancel")
+        val options = arrayOf(
+            getString(R.string.choose_from_gallery),
+            getString(R.string.take_photo),
+            getString(R.string.cancel)
+        )
         AlertDialog.Builder(requireContext())
-            .setTitle("Select Image")
+            .setTitle(getString(R.string.select_image))
             .setItems(options) { _, which ->
                 when (which) {
                     0 -> imagePickerLauncher.launch("image/*")
@@ -230,12 +234,12 @@ class ProfileFragment : Fragment() {
             requireContext().dataStore.data.map { preferences ->
                 User(
                     id = "1",
-                    name = preferences[NAME_KEY] ?: "John Doe",
-                    email = preferences[EMAIL_KEY] ?: "john@example.com",
+                    name = preferences[NAME_KEY] ?: getString(R.string.default_user_name),
+                    email = preferences[EMAIL_KEY] ?: getString(R.string.default_user_email),
                     photoUri = preferences[PHOTO_KEY],
                     batteryCapacity = preferences[CAPACITY_KEY] ?: 100,
                     warningLevel = preferences[WARNING_KEY] ?: 30,
-                    currentMood = preferences[MOOD_KEY] ?: "neutral",
+                    currentMood = preferences[MOOD_KEY] ?: getString(R.string.default_mood),
                     notificationsEnabled = preferences[NOTIFICATIONS_KEY] ?: true
                 )
             }.collect { user ->
@@ -250,9 +254,9 @@ class ProfileFragment : Fragment() {
             nameEditText.setText(user.name)
             emailEditText.setText(user.email)
             capacitySeekBar.progress = user.batteryCapacity
-            capacityText.text = "${user.batteryCapacity}%"
+            capacityText.text = getString(R.string.percent_format, user.batteryCapacity)
             warningSeekBar.progress = user.warningLevel
-            warningText.text = "${user.warningLevel}%"
+            warningText.text = getString(R.string.percent_format, user.warningLevel)
             notificationsSwitch.isChecked = user.notificationsEnabled
             
             user.photoUri?.let { uri ->
@@ -263,7 +267,7 @@ class ProfileFragment : Fragment() {
     }
 
     private fun toggleEditMode() {
-        val isEditMode = editProfileButton.text == "Edit Profile"
+        val isEditMode = editProfileButton.text == getString(R.string.edit_profile)
         
         if (isEditMode) {
             // Switch to edit mode
@@ -273,7 +277,7 @@ class ProfileFragment : Fragment() {
             warningSeekBar.isEnabled = true
             moodSpinner.isEnabled = true
             notificationsSwitch.isEnabled = true
-            editProfileButton.text = "Save Changes"
+            editProfileButton.text = getString(R.string.save_changes)
         } else {
             // Save changes and switch to view mode
             saveProfileChanges()
@@ -283,7 +287,7 @@ class ProfileFragment : Fragment() {
             warningSeekBar.isEnabled = false
             moodSpinner.isEnabled = false
             notificationsSwitch.isEnabled = false
-            editProfileButton.text = "Edit Profile"
+            editProfileButton.text = getString(R.string.edit_profile)
         }
     }
 
@@ -297,7 +301,7 @@ class ProfileFragment : Fragment() {
                 preferences[NOTIFICATIONS_KEY] = notificationsSwitch.isChecked
                 preferences[MOOD_KEY] = getMoodFromSpinner()
             }
-            Toast.makeText(requireContext(), "Profile updated successfully", Toast.LENGTH_SHORT).show()
+            Toast.makeText(requireContext(), getString(R.string.profile_updated_success), Toast.LENGTH_SHORT).show()
         }
     }
 
@@ -311,51 +315,52 @@ class ProfileFragment : Fragment() {
 
     private fun getMoodFromSpinner(): String {
         val moods = resources.getStringArray(R.array.mood_options)
-        return moods.getOrNull(moodSpinner.selectedItemPosition)?.lowercase() ?: "neutral"
+        return moods.getOrNull(moodSpinner.selectedItemPosition)?.lowercase()
+            ?: getString(R.string.default_mood)
     }
 
     private fun showSignOutDialog() {
         AlertDialog.Builder(requireContext())
-            .setTitle("Sign Out")
-            .setMessage("Are you sure you want to sign out?")
-            .setPositiveButton("Sign Out") { _, _ ->
+            .setTitle(getString(R.string.sign_out_title))
+            .setMessage(getString(R.string.sign_out_message))
+            .setPositiveButton(getString(R.string.sign_out)) { _, _ ->
                 performSignOut()
             }
-            .setNegativeButton("Cancel", null)
+            .setNegativeButton(getString(R.string.cancel), null)
             .show()
     }
 
     private fun showDeleteAccountDialog() {
         AlertDialog.Builder(requireContext())
-            .setTitle("Delete Account")
-            .setMessage("Are you sure you want to delete your account? This action cannot be undone.")
-            .setPositiveButton("Delete") { _, _ ->
+            .setTitle(getString(R.string.delete_account_title))
+            .setMessage(getString(R.string.delete_account_message))
+            .setPositiveButton(getString(R.string.delete)) { _, _ ->
                 performDeleteAccount()
             }
-            .setNegativeButton("Cancel", null)
+            .setNegativeButton(getString(R.string.cancel), null)
             .show()
     }
 
     private fun showRecalibrationDialog() {
         AlertDialog.Builder(requireContext())
-            .setTitle("Battery Recalibration")
-            .setMessage("This will reset your battery settings to default values and recalibrate based on your recent activity. Continue?")
-            .setPositiveButton("Recalibrate") { _, _ ->
+            .setTitle(getString(R.string.battery_recalibration_title))
+            .setMessage(getString(R.string.battery_recalibration_message))
+            .setPositiveButton(getString(R.string.recalibrate)) { _, _ ->
                 performRecalibration()
             }
-            .setNegativeButton("Cancel", null)
+            .setNegativeButton(getString(R.string.cancel), null)
             .show()
     }
 
     private fun showSurveyDialog() {
         AlertDialog.Builder(requireContext())
-            .setTitle("Social Battery Survey")
-            .setMessage("Take a quick survey to help us better understand your social energy patterns and improve your experience.")
-            .setPositiveButton("Take Survey") { _, _ ->
+            .setTitle(getString(R.string.survey_title))
+            .setMessage(getString(R.string.survey_message))
+            .setPositiveButton(getString(R.string.take_survey)) { _, _ ->
                 // In a real app, this would open a survey activity or web view
-                Toast.makeText(requireContext(), "Survey feature coming soon!", Toast.LENGTH_SHORT).show()
+                Toast.makeText(requireContext(), getString(R.string.survey_coming_soon), Toast.LENGTH_SHORT).show()
             }
-            .setNegativeButton("Later", null)
+            .setNegativeButton(getString(R.string.later), null)
             .show()
     }
 
@@ -364,7 +369,7 @@ class ProfileFragment : Fragment() {
             requireContext().dataStore.edit { preferences ->
                 preferences.clear()
             }
-            Toast.makeText(requireContext(), "Signed out successfully", Toast.LENGTH_SHORT).show()
+            Toast.makeText(requireContext(), getString(R.string.sign_out_success), Toast.LENGTH_SHORT).show()
             requireActivity().finish()
         }
     }
@@ -375,7 +380,7 @@ class ProfileFragment : Fragment() {
                 preferences.clear()
             }
             // In a real app, this would also delete from server/database
-            Toast.makeText(requireContext(), "Account deleted successfully", Toast.LENGTH_SHORT).show()
+            Toast.makeText(requireContext(), getString(R.string.account_deleted_success), Toast.LENGTH_SHORT).show()
             requireActivity().finish()
         }
     }
@@ -387,7 +392,7 @@ class ProfileFragment : Fragment() {
                 preferences[WARNING_KEY] = 30
             }
             loadUserProfile()
-            Toast.makeText(requireContext(), "Battery recalibrated successfully", Toast.LENGTH_SHORT).show()
+            Toast.makeText(requireContext(), getString(R.string.battery_recalibrated_success), Toast.LENGTH_SHORT).show()
         }
     }
 }

--- a/app/src/main/java/com/example/socialbatterymanager/onboarding/OnboardingFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/onboarding/OnboardingFragment.kt
@@ -93,11 +93,11 @@ class OnboardingFragment : Fragment() {
     private fun showBiometricSetupDialog() {
         val builder = androidx.appcompat.app.AlertDialog.Builder(requireContext())
         builder.setTitle(getString(R.string.biometric_title))
-        builder.setMessage("Would you like to enable biometric authentication for secure access to your social battery data?")
-        builder.setPositiveButton("Yes") { _, _ ->
+        builder.setMessage(getString(R.string.biometric_setup_message))
+        builder.setPositiveButton(getString(R.string.yes)) { _, _ ->
             setupBiometricAuthentication()
         }
-        builder.setNegativeButton("Skip") { _, _ ->
+        builder.setNegativeButton(getString(R.string.skip)) { _, _ ->
             finalizeOnboarding()
         }
         builder.setCancelable(false)

--- a/app/src/main/java/com/example/socialbatterymanager/shared/utils/BiometricAuthHelper.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/shared/utils/BiometricAuthHelper.kt
@@ -98,12 +98,12 @@ enum class BiometricAvailability {
  */
 fun BiometricAvailability.getMessage(context: Context): String {
     return when (this) {
-        BiometricAvailability.AVAILABLE -> "Biometric authentication available"
-        BiometricAvailability.NO_HARDWARE -> "No biometric hardware available"
-        BiometricAvailability.HW_UNAVAILABLE -> "Biometric hardware unavailable"
-        BiometricAvailability.NONE_ENROLLED -> "No biometric credentials enrolled"
-        BiometricAvailability.SECURITY_UPDATE_REQUIRED -> "Security update required"
-        BiometricAvailability.UNSUPPORTED -> "Biometric authentication not supported"
-        BiometricAvailability.UNKNOWN -> "Unknown biometric status"
+        BiometricAvailability.AVAILABLE -> context.getString(R.string.biometric_available_message)
+        BiometricAvailability.NO_HARDWARE -> context.getString(R.string.biometric_no_hardware)
+        BiometricAvailability.HW_UNAVAILABLE -> context.getString(R.string.biometric_hw_unavailable)
+        BiometricAvailability.NONE_ENROLLED -> context.getString(R.string.biometric_none_enrolled)
+        BiometricAvailability.SECURITY_UPDATE_REQUIRED -> context.getString(R.string.biometric_security_update_required)
+        BiometricAvailability.UNSUPPORTED -> context.getString(R.string.biometric_unsupported)
+        BiometricAvailability.UNKNOWN -> context.getString(R.string.biometric_unknown_status)
     }
 }

--- a/app/src/main/java/com/example/socialbatterymanager/shared/utils/NetworkConnectivityManager.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/shared/utils/NetworkConnectivityManager.kt
@@ -8,6 +8,7 @@ import android.net.NetworkRequest
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import com.example.socialbatterymanager.R
 
 /**
  * Utility class for monitoring network connectivity
@@ -126,9 +127,9 @@ enum class ConnectionType {
  */
 fun ConnectionType.getMessage(context: Context): String {
     return when (this) {
-        ConnectionType.WIFI -> "Connected via Wi-Fi"
-        ConnectionType.MOBILE -> "Connected via Mobile Data"
-        ConnectionType.ETHERNET -> "Connected via Ethernet"
-        ConnectionType.NONE -> "Not connected"
+        ConnectionType.WIFI -> context.getString(R.string.connection_wifi)
+        ConnectionType.MOBILE -> context.getString(R.string.connection_mobile)
+        ConnectionType.ETHERNET -> context.getString(R.string.connection_ethernet)
+        ConnectionType.NONE -> context.getString(R.string.connection_none)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,10 +108,57 @@
     <string name="mood_unknown">Mood: Unknown</string>
     <string name="activities_0">Activities: 0</string>
 
-    <!-- Reports strings -->
-    <string name="date">Date</string>
-    <string name="energy_0_0">Energy: 0.0</string>
-    <string name="mood_unknown">Mood: Unknown</string>
-    <string name="activities_0">Activities: 0</string>
+    <!-- Connectivity status messages -->
+    <string name="connection_wifi">Connected via Wi-Fi</string>
+    <string name="connection_mobile">Connected via Mobile Data</string>
+    <string name="connection_ethernet">Connected via Ethernet</string>
+    <string name="connection_none">Not connected</string>
+
+    <!-- Biometric availability messages -->
+    <string name="biometric_available_message">Biometric authentication available</string>
+    <string name="biometric_no_hardware">No biometric hardware available</string>
+    <string name="biometric_hw_unavailable">Biometric hardware unavailable</string>
+    <string name="biometric_none_enrolled">No biometric credentials enrolled</string>
+    <string name="biometric_security_update_required">Security update required</string>
+    <string name="biometric_unsupported">Biometric authentication not supported</string>
+    <string name="biometric_unknown_status">Unknown biometric status</string>
+    <string name="biometric_setup_message">Would you like to enable biometric authentication for secure access to your social battery data?</string>
+    <string name="yes">Yes</string>
+
+    <!-- Profile strings -->
+    <string name="permission_denied">Permission denied</string>
+    <string name="permission_access_photos">Permission needed to access photos</string>
+    <string name="choose_from_gallery">Choose from Gallery</string>
+    <string name="take_photo">Take Photo</string>
+    <string name="cancel">Cancel</string>
+    <string name="select_image">Select Image</string>
+    <string name="default_user_name">John Doe</string>
+    <string name="default_user_email">john@example.com</string>
+    <string name="default_mood">neutral</string>
+    <string name="percent_format">%1$d%%</string>
+    <string name="edit_profile">Edit Profile</string>
+    <string name="save_changes">Save Changes</string>
+    <string name="profile_updated_success">Profile updated successfully</string>
+    <string name="sign_out_title">Sign Out</string>
+    <string name="sign_out_message">Are you sure you want to sign out?</string>
+    <string name="sign_out">Sign Out</string>
+    <string name="delete_account_title">Delete Account</string>
+    <string name="delete_account_message">Are you sure you want to delete your account? This action cannot be undone.</string>
+    <string name="delete">Delete</string>
+    <string name="battery_recalibration_title">Battery Recalibration</string>
+    <string name="battery_recalibration_message">This will reset your battery settings to default values and recalibrate based on your recent activity. Continue?</string>
+    <string name="recalibrate">Recalibrate</string>
+    <string name="survey_title">Social Battery Survey</string>
+    <string name="survey_message">Take a quick survey to help us better understand your social energy patterns and improve your experience.</string>
+    <string name="take_survey">Take Survey</string>
+    <string name="later">Later</string>
+    <string name="survey_coming_soon">Survey feature coming soon!</string>
+    <string name="sign_out_success">Signed out successfully</string>
+    <string name="account_deleted_success">Account deleted successfully</string>
+    <string name="battery_recalibrated_success">Battery recalibrated successfully</string>
+
+    <!-- Login strings -->
+    <string name="enter_email_password">Please enter email and password</string>
+    <string name="google_sign_in_failed">Google sign in failed: %1$s</string>
 
 </resources>


### PR DESCRIPTION
## Summary
- Localize connection and biometric status messages
- Replace inline UI text in onboarding, profile, and login flows with string resources
- Add comprehensive string resources for dialogs, toasts, and prompts

## Testing
- `./gradlew test` *(fails: Build was configured to prefer settings repositories over project repositories but repository 'Google' was added by build file 'build.gradle.kts')*

------
https://chatgpt.com/codex/tasks/task_e_688e018411448324ace4ceae92890ee2