### PR TITLE
Clarify absence of Google/Teams calendar integration

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/calendar/CalendarIntegration.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/calendar/CalendarIntegration.kt
@@ -81,20 +81,30 @@ class CalendarIntegration(
         events
     }
     
+    /**
+     * Placeholder for Google Calendar integration.
+     *
+     * Returns an empty list until a real API integration is provided.
+     */
     suspend fun importGoogleCalendarEvents(): List<CalendarEvent> = withContext(Dispatchers.IO) {
-        // TODO: Implement Google Calendar API integration
-        // This would require Google Play Services and OAuth setup
-        // For now, we'll return events from device calendar that are Google-sourced
-        val allEvents = calendarEventDao.getEventsBySource("google")
-        allEvents
+        Log.i(
+            "CalendarIntegration",
+            "Google Calendar integration not available; returning empty list."
+        )
+        emptyList()
     }
-    
+
+    /**
+     * Placeholder for Microsoft Teams calendar integration.
+     *
+     * Returns an empty list until a real API integration is provided.
+     */
     suspend fun importTeamsCalendarEvents(): List<CalendarEvent> = withContext(Dispatchers.IO) {
-        // TODO: Implement Microsoft Teams Calendar API integration
-        // This would require Microsoft Graph API setup
-        // For now, we'll return events from device calendar that are Teams-sourced
-        val allEvents = calendarEventDao.getEventsBySource("teams")
-        allEvents
+        Log.i(
+            "CalendarIntegration",
+            "Microsoft Teams calendar integration not available; returning empty list."
+        )
+        emptyList()
     }
     
     suspend fun createManualEvent(


### PR DESCRIPTION
## Summary
- Note that Google Calendar integration is unavailable and return an empty list instead of filtered device events
- Note that Microsoft Teams calendar integration is unavailable and return an empty list instead of filtered device events

## Testing
- `./gradlew test` *(fails: Build was configured to prefer settings repositories over project repositories but repository 'Google' was added by build file)*

------
https://chatgpt.com/codex/tasks/task_e_688e064ed5d0832483203fdfeb9b6d4c