### PR TITLE
Enable minify for release build and add ProGuard keep rules

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,7 +21,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,7 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Keep data model classes used for Gson serialization and Firebase
+# to ensure fields are not stripped or obfuscated during minification.
+-keep class com.example.socialbatterymanager.data.model.** { *; }


### PR DESCRIPTION
## Summary
- Enable R8/ProGuard minification for the release build
- Keep data model classes so Gson/Firebase serialization works after obfuscation

## Testing
- `./gradlew assembleRelease` *(fails: Build was configured to prefer settings repositories over project repositories but repository 'Google' was added by build file `build.gradle.kts`)*


------
https://chatgpt.com/codex/tasks/task_e_688e0650a0008324b0d90a35c397928f