### PR TITLE
Improve error logging in sync and main activity

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/MainActivity.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.example.socialbatterymanager
 
 import android.os.Bundle
+import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.lifecycle.lifecycleScope
@@ -65,7 +66,8 @@ class MainActivity : AppCompatActivity() {
                 syncManager.schedulePeriodicSync()
             } catch (e: Exception) {
                 // Handle sync initialization error
-                e.printStackTrace()
+                Log.e("MainActivity", "Failed to schedule periodic sync", e)
+                // TODO: Forward to crash-reporting service
             }
         }
     }

--- a/app/src/main/java/com/example/socialbatterymanager/sync/SyncWorker.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/sync/SyncWorker.kt
@@ -1,6 +1,7 @@
 package com.example.socialbatterymanager.sync
 
 import android.content.Context
+import android.util.Log
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.example.socialbatterymanager.data.database.AppDatabase
@@ -9,7 +10,6 @@ import com.example.socialbatterymanager.data.model.SyncStatus
 import com.example.socialbatterymanager.shared.utils.NetworkConnectivityManager
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
-import kotlinx.coroutines.flow.first
 
 /**
  * Worker class for syncing local data with Firebase
@@ -38,7 +38,8 @@ class SyncWorker(
             
             Result.success()
         } catch (e: Exception) {
-            e.printStackTrace()
+            Log.e("SyncWorker", "Error during synchronization work", e)
+            // TODO: Forward to crash-reporting service
             Result.retry()
         } finally {
             networkManager.unregister()
@@ -85,7 +86,8 @@ class SyncWorker(
             } catch (e: Exception) {
                 // Mark as sync error
                 database.activityDao().updateSyncStatus(activity.id, SyncStatus.SYNC_ERROR)
-                e.printStackTrace()
+                Log.e("SyncWorker", "Failed to sync activity ${activity.id}", e)
+                // TODO: Forward to crash-reporting service
             }
         }
     }
@@ -137,7 +139,8 @@ class SyncWorker(
             }
             
         } catch (e: Exception) {
-            e.printStackTrace()
+            Log.e("SyncWorker", "Failed to download updates from Firebase", e)
+            // TODO: Forward to crash-reporting service
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace `printStackTrace` calls with `Log.e` in `MainActivity` and `SyncWorker`
- Add placeholder comments for forwarding errors to a crash-reporting service

## Testing
- `./gradlew test` *(fails: Build was configured to prefer settings repositories over project repositories but repository 'Google' was added by build file 'build.gradle.kts')*

------
https://chatgpt.com/codex/tasks/task_e_688e06512c8c8324949bc5389127603a