### PR TITLE
Guard sample notifications behind debug flag and externalize text

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/features/home/ui/SimpleHomeFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/home/ui/SimpleHomeFragment.kt
@@ -10,6 +10,7 @@ import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import com.example.socialbatterymanager.BuildConfig
 import com.example.socialbatterymanager.R
 import com.example.socialbatterymanager.data.database.AppDatabase
 import com.example.socialbatterymanager.features.notifications.NotificationService
@@ -48,7 +49,9 @@ class SimpleHomeFragment : Fragment() {
         tvEnergyLevel = view.findViewById(R.id.tvEnergyLevel)
 
         setupClickListeners()
-        generateSampleNotifications()
+        if (BuildConfig.DEBUG) {
+            generateSampleNotifications()
+        }
         updateWeeklyStats()
 
         return view
@@ -86,8 +89,10 @@ class SimpleHomeFragment : Fragment() {
     }
 
     private fun generateSampleNotifications() {
-        lifecycleScope.launch {
-            notificationService.generateSampleNotifications()
+        if (BuildConfig.DEBUG) {
+            lifecycleScope.launch {
+                notificationService.generateSampleNotifications()
+            }
         }
     }
 

--- a/app/src/main/java/com/example/socialbatterymanager/features/notifications/NotificationService.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/notifications/NotificationService.kt
@@ -1,6 +1,8 @@
 package com.example.socialbatterymanager.features.notifications
 
 import android.content.Context
+import com.example.socialbatterymanager.BuildConfig
+import com.example.socialbatterymanager.R
 import com.example.socialbatterymanager.data.database.AppDatabase
 import com.example.socialbatterymanager.data.model.NotificationEntity
 import com.example.socialbatterymanager.data.model.NotificationType
@@ -15,6 +17,7 @@ class NotificationService(private val context: Context) {
     private val scope = CoroutineScope(Dispatchers.IO)
     
     fun generateSampleNotifications() {
+        if (!BuildConfig.DEBUG) return
         scope.launch {
             // Retrieve current notifications to avoid duplicate inserts
             val existingNotifications =
@@ -25,20 +28,20 @@ class NotificationService(private val context: Context) {
                 val notifications = listOf(
                     NotificationEntity(
                         type = NotificationType.ENERGY_LOW.name,
-                        title = "Energy Running Low",
-                        message = "Your social energy is at 25%. Time to recharge!",
+                        title = context.getString(R.string.notification_energy_low_title),
+                        message = context.getString(R.string.notification_energy_low_sample_message),
                         timestamp = System.currentTimeMillis() - (2 * 60 * 1000) // 2 minutes ago
                     ),
                     NotificationEntity(
                         type = NotificationType.BUSY_WEEK.name,
-                        title = "Busy Week Ahead",
-                        message = "You have 6 social activities scheduled. Plan recovery time!",
+                        title = context.getString(R.string.notification_busy_week_title),
+                        message = context.getString(R.string.notification_busy_week_sample_message),
                         timestamp = System.currentTimeMillis() - (60 * 60 * 1000) // 1 hour ago
                     ),
                     NotificationEntity(
                         type = NotificationType.RATE_ACTIVITY.name,
-                        title = "Rate Your Activity",
-                        message = "How was your team meeting? Help us track your energy better.",
+                        title = context.getString(R.string.notification_rate_activity_title),
+                        message = context.getString(R.string.notification_rate_activity_sample_message),
                         timestamp = System.currentTimeMillis() - (3 * 60 * 60 * 1000), // 3 hours ago
                         activityId = 1 // Assuming there's an activity with ID 1
                     )
@@ -56,8 +59,8 @@ class NotificationService(private val context: Context) {
             scope.launch {
                 val notification = NotificationEntity(
                     type = NotificationType.ENERGY_LOW.name,
-                    title = "Energy Running Low",
-                    message = "Your social energy is at $currentEnergyLevel%. Consider taking a break!",
+                    title = context.getString(R.string.notification_energy_low_title),
+                    message = context.getString(R.string.notification_energy_low_message, currentEnergyLevel),
                     timestamp = System.currentTimeMillis()
                 )
                 database.notificationDao().insertNotification(notification)
@@ -69,8 +72,8 @@ class NotificationService(private val context: Context) {
         scope.launch {
             val notification = NotificationEntity(
                 type = NotificationType.RATE_ACTIVITY.name,
-                title = "Rate Your Activity",
-                message = "How was $activityName? Help us track your energy better.",
+                title = context.getString(R.string.notification_rate_activity_title),
+                message = context.getString(R.string.notification_rate_activity_message, activityName),
                 timestamp = System.currentTimeMillis(),
                 activityId = activityId
             )
@@ -82,8 +85,8 @@ class NotificationService(private val context: Context) {
         scope.launch {
             val notification = NotificationEntity(
                 type = NotificationType.BUSY_WEEK.name,
-                title = "Busy Week Ahead",
-                message = "You have $activitiesCount social activities scheduled. Plan recovery time!",
+                title = context.getString(R.string.notification_busy_week_title),
+                message = context.getString(R.string.notification_busy_week_message, activitiesCount),
                 timestamp = System.currentTimeMillis()
             )
             database.notificationDao().insertNotification(notification)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -190,6 +190,17 @@
     <string name="account_deleted_success">Account deleted successfully</string>
     <string name="battery_recalibrated_success">Battery recalibrated successfully</string>
 
+    <!-- Notification strings -->
+    <string name="notification_energy_low_title">Energy Running Low</string>
+    <string name="notification_energy_low_message">Your social energy is at %1$d%%. Consider taking a break!</string>
+    <string name="notification_energy_low_sample_message">Your social energy is at 25%%. Time to recharge!</string>
+    <string name="notification_busy_week_title">Busy Week Ahead</string>
+    <string name="notification_busy_week_message">You have %1$d social activities scheduled. Plan recovery time!</string>
+    <string name="notification_busy_week_sample_message">You have 6 social activities scheduled. Plan recovery time!</string>
+    <string name="notification_rate_activity_title">Rate Your Activity</string>
+    <string name="notification_rate_activity_message">How was %1$s? Help us track your energy better.</string>
+    <string name="notification_rate_activity_sample_message">How was your team meeting? Help us track your energy better.</string>
+
     <!-- Login strings -->
     <string name="enter_email_password">Please enter email and password</string>
     <string name="google_sign_in_failed">Google sign in failed: %1$s</string>


### PR DESCRIPTION
## Summary
- Restrict sample notification generation to debug builds only
- Move notification titles and messages into `strings.xml`
- Use `getString` references for notification text throughout

## Testing
- `./gradlew test` *(fails: Build was configured to prefer settings repositories over project repositories)*

------
https://chatgpt.com/codex/tasks/task_e_688e0c98dec883249127e1bb89cd1280