### PR TITLE
Clarify unimplemented calendar APIs

### DIFF
--- a/CALENDAR_README.md
+++ b/CALENDAR_README.md
@@ -6,10 +6,11 @@ This document describes the calendar functionality implemented for the Social Ba
 
 The calendar feature allows users to:
 - View events in a calendar interface
-- Import events from device calendar (Google, Teams, Outlook)
+- Import events from the device calendar
 - Create manual events
 - Store events locally in Room database
 - View events for selected dates
+- Direct integrations with Google Calendar and Microsoft Teams are not yet implemented
 
 ## Files Implemented
 
@@ -47,8 +48,8 @@ The calendar feature allows users to:
 ### 3. Event Import
 - Device calendar integration
 - Permission handling for READ_CALENDAR
-- Support for Google, Teams, Outlook calendars
-- Source detection based on calendar name
+- Source detection for Google, Teams, Outlook calendars based on calendar name
+- Direct API integrations for Google Calendar and Microsoft Teams are not yet available
 
 ### 4. Event Display
 - RecyclerView showing events for selected date

--- a/app/src/main/java/com/example/socialbatterymanager/calendar/CalendarIntegration.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/calendar/CalendarIntegration.kt
@@ -7,8 +7,13 @@ import com.example.socialbatterymanager.data.model.CalendarEvent
 import com.example.socialbatterymanager.data.model.CalendarEventDao
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.util.Calendar
 
+/**
+ * Handles interactions with the user's calendars.
+ *
+ * Only events available on the device's calendar can be imported. Direct API
+ * integrations for Google Calendar or Microsoft Teams are not implemented.
+ */
 class CalendarIntegration(
     private val context: Context,
     private val calendarEventDao: CalendarEventDao
@@ -79,32 +84,6 @@ class CalendarIntegration(
         }
         
         events
-    }
-    
-    /**
-     * Placeholder for Google Calendar integration.
-     *
-     * Returns an empty list until a real API integration is provided.
-     */
-    suspend fun importGoogleCalendarEvents(): List<CalendarEvent> = withContext(Dispatchers.IO) {
-        Log.i(
-            "CalendarIntegration",
-            "Google Calendar integration not available; returning empty list."
-        )
-        emptyList()
-    }
-
-    /**
-     * Placeholder for Microsoft Teams calendar integration.
-     *
-     * Returns an empty list until a real API integration is provided.
-     */
-    suspend fun importTeamsCalendarEvents(): List<CalendarEvent> = withContext(Dispatchers.IO) {
-        Log.i(
-            "CalendarIntegration",
-            "Microsoft Teams calendar integration not available; returning empty list."
-        )
-        emptyList()
     }
     
     suspend fun createManualEvent(

--- a/app/src/main/res/layout/fragment_calendar.xml
+++ b/app/src/main/res/layout/fragment_calendar.xml
@@ -119,7 +119,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Sync from Google Calendar, Outlook"
+                android:text="Sync from device calendars (e.g., Google, Outlook)"
                 android:textSize="14sp"
                 android:textColor="@color/jscc_charcoal"
                 android:layout_marginBottom="12dp" />
@@ -137,3 +137,4 @@
     </LinearLayout>
 
 </ScrollView>
+


### PR DESCRIPTION
## Summary
- remove unused Google/Microsoft Teams calendar stubs
- document that only device calendar imports are supported
- update calendar sync UI text

## Testing
- `./gradlew test` *(fails: Build was configured to prefer settings repositories over project repositories but repository 'Google' was added by build file 'build.gradle.kts')*

------
https://chatgpt.com/codex/tasks/task_e_688e0c99ad288324af610d5b94739d06