### PR TITLE
Query peak day from activity counts

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/features/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/home/ui/HomeFragment.kt
@@ -229,16 +229,17 @@ class HomeFragment : Fragment() {
         }
     }
 
-    private fun findPeakDay(): String {
+    private suspend fun findPeakDay(): String {
         val dayFormatter = SimpleDateFormat("EEEE", Locale.getDefault())
-        val calendar = Calendar.getInstance()
-        
-        // For demo purposes, return a day based on current day
-        val dayOfWeek = calendar.get(Calendar.DAY_OF_WEEK)
-        return when (dayOfWeek) {
-            Calendar.SATURDAY, Calendar.SUNDAY -> "Saturday"
-            else -> "Friday"
-        }
+        val now = System.currentTimeMillis()
+        val weekStart = now - TimeUnit.DAYS.toMillis(7)
+
+        val activities = database.activityDao().getActivitiesByDateRangeSync(weekStart, now)
+        val countsByDay = activities.groupingBy { activity ->
+            dayFormatter.format(Date(activity.date))
+        }.eachCount()
+
+        return countsByDay.maxByOrNull { it.value }?.key ?: dayFormatter.format(Date())
     }
 
     private fun calculateRecoveryNeeded(avgEnergy: Int): Int {


### PR DESCRIPTION
## Summary
- compute real peak activity day using database query
- localize day names when reporting peak day

## Testing
- `./gradlew test` *(fails: Build was configured to prefer settings repositories over project repositories but repository 'Google' was added by build file 'build.gradle.kts')*

------
https://chatgpt.com/codex/tasks/task_e_688e0c99ffb08324b9dff7f672b54006