### PR TITLE
Use string resources for weekly stats

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/features/home/ui/SimpleHomeFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/home/ui/SimpleHomeFragment.kt
@@ -101,9 +101,9 @@ class SimpleHomeFragment : Fragment() {
             val weekStart = System.currentTimeMillis() - (7 * 24 * 60 * 60 * 1000)
             try {
                 val activityCount = database.activityDao().getActiveActivityCount()
-                tvWeeklyStats.text = "This week: $activityCount activities tracked"
+                tvWeeklyStats.text = getString(R.string.weekly_stats_message, activityCount)
             } catch (e: Exception) {
-                tvWeeklyStats.text = "Weekly stats loading..."
+                tvWeeklyStats.text = getString(R.string.weekly_stats_loading)
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,8 @@
     <string name="battery_percent_65">65%</string>
     <string name="remove_energy">- Remove Energy</string>
     <string name="add_energy">+ Add Energy</string>
+    <string name="weekly_stats_message">This week: %1$d activities tracked</string>
+    <string name="weekly_stats_loading">Weekly stats loading...</string>
     <string name="app_name">Social Battery Manager</string>
     <string name="activities_title">Activities</string>
     <string name="activities_empty">No activities yet. Tap the + button to add one!</string>


### PR DESCRIPTION
## Summary
- replace hardcoded weekly stats text with string resources
- show weekly stats using localized messages

## Testing
- `./gradlew test` *(fails: Build was configured to prefer settings repositories over project repositories but repository 'Google' was added)*

------
https://chatgpt.com/codex/tasks/task_e_688e14766a6883249584975f5e924fba