### PR TITLE
Refactor energy recommendations to use string resources

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/features/energy/EnergyManager.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/energy/EnergyManager.kt
@@ -1,9 +1,9 @@
 package com.example.socialbatterymanager.features.energy
 
 import com.example.socialbatterymanager.BuildConfig
+import com.example.socialbatterymanager.R
 import com.example.socialbatterymanager.data.model.CalendarEvent
 import com.example.socialbatterymanager.data.model.CalendarActivityEvent
-import com.example.socialbatterymanager.data.model.EnergyLog
 import java.util.Calendar
 
 /**
@@ -68,32 +68,37 @@ class EnergyManager {
      * Get recommended energy allocation for remaining activities
      */
     fun getEnergyRecommendations(energyState: EnergyState, upcomingEvents: List<CalendarEvent>): EnergyRecommendations {
-        val recommendations = mutableListOf<String>()
-        
+        val recommendations = mutableListOf<EnergyRecommendation>()
+
         when {
             energyState.currentEnergyLevel >= 75 -> {
-                recommendations.add("Great energy levels! You can handle demanding activities.")
+                recommendations.add(EnergyRecommendation(R.string.energy_recommendation_great))
             }
             energyState.currentEnergyLevel >= 50 -> {
-                recommendations.add("Good energy. Consider lighter activities in the afternoon.")
+                recommendations.add(EnergyRecommendation(R.string.energy_recommendation_good))
             }
             energyState.currentEnergyLevel >= 25 -> {
-                recommendations.add("Energy running low. Take breaks and avoid high-stress activities.")
+                recommendations.add(EnergyRecommendation(R.string.energy_recommendation_low))
             }
             else -> {
-                recommendations.add("Very low energy. Consider rescheduling non-essential activities.")
+                recommendations.add(EnergyRecommendation(R.string.energy_recommendation_very_low))
             }
         }
-        
+
         // Check upcoming activities
-        val upcomingBurn = upcomingEvents.sumOf { 
-            CalendarActivityEvent.fromCalendarEvent(it).calculateEnergyBurn() 
+        val upcomingBurn = upcomingEvents.sumOf {
+            CalendarActivityEvent.fromCalendarEvent(it).calculateEnergyBurn()
         }
-        
+
         if (upcomingBurn > energyState.remainingHours) {
-            recommendations.add("Warning: Planned activities exceed available energy (${upcomingBurn}h vs ${energyState.remainingHours}h)")
+            recommendations.add(
+                EnergyRecommendation(
+                    R.string.energy_warning_planned_exceed,
+                    listOf<Any>(upcomingBurn, energyState.remainingHours)
+                )
+            )
         }
-        
+
         return EnergyRecommendations(
             recommendations = recommendations,
             warningLevel = when {
@@ -188,7 +193,7 @@ data class EnergyState(
  * Energy recommendations and warnings
  */
 data class EnergyRecommendations(
-    val recommendations: List<String>,
+    val recommendations: List<EnergyRecommendation>,
     val warningLevel: WarningLevel,
     val suggestedBreakDuration: Int // In minutes
 )
@@ -196,3 +201,11 @@ data class EnergyRecommendations(
 enum class WarningLevel {
     LOW, MEDIUM, HIGH
 }
+
+/**
+ * Recommendation message referencing a string resource and optional format arguments
+ */
+data class EnergyRecommendation(
+    val messageRes: Int,
+    val formatArgs: List<Any> = emptyList()
+)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,6 +70,13 @@
     <string name="burn_rate">Burn Rate</string>
     <string name="hours_left">%1$.1fh\nSocial energy left</string>
     <string name="burn_rate_value">%1$.1fh\nPer social activity</string>
+
+    <!-- Energy Recommendations -->
+    <string name="energy_recommendation_great">Great energy levels! You can handle demanding activities.</string>
+    <string name="energy_recommendation_good">Good energy. Consider lighter activities in the afternoon.</string>
+    <string name="energy_recommendation_low">Energy running low. Take breaks and avoid high-stress activities.</string>
+    <string name="energy_recommendation_very_low">Very low energy. Consider rescheduling non-essential activities.</string>
+    <string name="energy_warning_planned_exceed">Warning: Planned activities exceed available energy (%1$.1fh vs %2$.1fh)</string>
     
     <!-- Weekly Forecast -->
     <string name="weekly_forecast_title">Weekly Forecast</string>

--- a/app/src/test/java/com/example/socialbatterymanager/features/energy/EnergyManagerTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/features/energy/EnergyManagerTest.kt
@@ -1,6 +1,7 @@
 package com.example.socialbatterymanager.features.energy
 
 import com.example.socialbatterymanager.data.model.CalendarEvent
+import com.example.socialbatterymanager.R
 import org.junit.Test
 import org.junit.Assert.*
 import java.util.Calendar
@@ -101,10 +102,12 @@ class EnergyManagerTest {
         )
         
         val recommendations = energyManager.getEnergyRecommendations(lowEnergyState, emptyList())
-        
+
         assertEquals(WarningLevel.HIGH, recommendations.warningLevel)
         assertTrue("Should suggest longer break for low energy", recommendations.suggestedBreakDuration >= 30)
-        assertTrue("Should contain energy warning", 
-            recommendations.recommendations.any { it.contains("low energy", ignoreCase = true) })
+        assertTrue(
+            "Should contain energy warning",
+            recommendations.recommendations.any { it.messageRes == R.string.energy_recommendation_very_low }
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Move EnergyManager recommendation text to `strings.xml`
- Return string resource IDs and format args for energy recommendations
- Adjust unit test for new localization approach

## Testing
- `./gradlew test` *(fails: Build was configured to prefer settings repositories over project repositories but repository 'Google' was added by build file 'build.gradle.kts')*

------
https://chatgpt.com/codex/tasks/task_e_688e1477664883248d63dd6f1bbf6027