### PR TITLE
Use string resources for calendar and contacts

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/calendar/CalendarIntegration.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/calendar/CalendarIntegration.kt
@@ -3,6 +3,7 @@ package com.example.socialbatterymanager.calendar
 import android.content.Context
 import android.provider.CalendarContract
 import android.util.Log
+import com.example.socialbatterymanager.R
 import com.example.socialbatterymanager.data.model.CalendarEvent
 import com.example.socialbatterymanager.data.model.CalendarEventDao
 import kotlinx.coroutines.Dispatchers
@@ -45,7 +46,7 @@ class CalendarIntegration(
             cursor?.use { c ->
                 while (c.moveToNext()) {
                     val externalId = c.getString(0) ?: ""
-                    val title = c.getString(1) ?: "Untitled Event"
+                    val title = c.getString(1) ?: context.getString(R.string.untitled_event)
                     val description = c.getString(2) ?: ""
                     val startTime = c.getLong(3)
                     val endTime = c.getLong(4)

--- a/app/src/main/java/com/example/socialbatterymanager/features/people/data/ContactsImporter.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/people/data/ContactsImporter.kt
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager
 import android.provider.ContactsContract
 import androidx.core.content.ContextCompat
 import com.example.socialbatterymanager.data.model.Person
+import com.example.socialbatterymanager.R
 
 class ContactsImporter(private val context: Context) {
     
@@ -52,7 +53,7 @@ class ContactsImporter(private val context: Context) {
                             name = name,
                             email = email,
                             phone = phone,
-                            notes = "Imported from contacts"
+                            notes = context.getString(R.string.imported_from_contacts)
                         )
                     )
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,11 +35,13 @@
     <string name="add_to_calendar">+ Create New Activity</string>
     <string name="import_events">Import Events</string>
     <string name="events_for_day">Events for Selected Day</string>
+    <string name="untitled_event">Untitled Event</string>
 
     <!-- People -->
     <string name="add_person">Add Person</string>
     <string name="edit_person">Edit Person</string>
     <string name="error_name_required">Name is required</string>
+    <string name="imported_from_contacts">Imported from contacts</string>
 
     <!-- Calendar messages -->
     <string name="event_label">Event: %1$s</string>


### PR DESCRIPTION
## Summary
- add `untitled_event` and `imported_from_contacts` string resources
- use `context.getString` for default calendar event and contact notes

## Testing
- `./gradlew test` *(fails: Build was configured to prefer settings repositories over project repositories but repository 'Google' was added)*

------
https://chatgpt.com/codex/tasks/task_e_688e1477645c832488149690b0cc5504