### PR TITLE
chore: guard requirements fragment for debug

### DIFF
--- a/app/src/debug/java/com/example/socialbatterymanager/requirements/RequirementsFragment.kt
+++ b/app/src/debug/java/com/example/socialbatterymanager/requirements/RequirementsFragment.kt
@@ -12,8 +12,9 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import com.example.requirements.RequirementsWebInterface
 import com.example.requirements.ComplexityLevel
+import com.example.socialbatterymanager.BuildConfig
+import com.example.socialbatterymanager.R
 import kotlinx.coroutines.launch
-import java.io.File
 
 
 /**
@@ -50,8 +51,10 @@ class RequirementsFragment : Fragment() {
         resultText = view.findViewById(R.id.resultText)
         complexityText = view.findViewById(R.id.complexityText)
         
-        // Load a sample requirement
-        loadSampleRequirement()
+        if (BuildConfig.DEBUG) {
+            // Load a sample requirement in debug builds
+            loadSampleRequirement()
+        }
     }
     
     private fun setupClickListeners() {
@@ -101,12 +104,12 @@ class RequirementsFragment : Fragment() {
         val requirements = requirementsInput.text.toString()
         
         if (requirements.isBlank()) {
-            Toast.makeText(context, "Please enter requirements", Toast.LENGTH_SHORT).show()
+            Toast.makeText(context, getString(R.string.requirements_enter_prompt), Toast.LENGTH_SHORT).show()
             return
         }
         
         generateButton.isEnabled = false
-        generateButton.text = "Generating..."
+        generateButton.text = getString(R.string.requirements_generating)
         
         lifecycleScope.launch {
             try {
@@ -118,14 +121,14 @@ class RequirementsFragment : Fragment() {
                 if (result.success) {
                     displayResults(result)
                 } else {
-                    resultText.text = "Error: ${result.message}"
+                    resultText.text = getString(R.string.requirements_error, result.message)
                 }
                 
             } catch (e: Exception) {
-                resultText.text = "Error: ${e.message}"
+                resultText.text = getString(R.string.requirements_error, e.message)
             } finally {
                 generateButton.isEnabled = true
-                generateButton.text = "Generate Code"
+                generateButton.text = getString(R.string.requirements_generate_code)
             }
         }
     }
@@ -134,7 +137,7 @@ class RequirementsFragment : Fragment() {
         val requirements = requirementsInput.text.toString()
         
         if (requirements.isBlank()) {
-            Toast.makeText(context, "Please enter requirements", Toast.LENGTH_SHORT).show()
+            Toast.makeText(context, getString(R.string.requirements_enter_prompt), Toast.LENGTH_SHORT).show()
             return
         }
         
@@ -184,7 +187,7 @@ class RequirementsFragment : Fragment() {
         resultText.text = output.toString()
         
         // Show success message
-        Toast.makeText(context, "Code generated successfully!", Toast.LENGTH_LONG).show()
+        Toast.makeText(context, getString(R.string.requirements_generate_success), Toast.LENGTH_LONG).show()
     }
     
     companion object {

--- a/app/src/debug/res/layout/fragment_requirements.xml
+++ b/app/src/debug/res/layout/fragment_requirements.xml
@@ -46,7 +46,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:text="Assess Complexity"
+                android:text="@string/requirements_assess_complexity"
                 android:layout_marginEnd="8dp"
                 android:backgroundTint="#FF9800" />
 
@@ -55,7 +55,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:text="Generate Code"
+                android:text="@string/requirements_generate_code"
                 android:layout_marginStart="8dp"
                 android:backgroundTint="#4CAF50" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -205,4 +205,12 @@
     <string name="enter_email_password">Please enter email and password</string>
     <string name="google_sign_in_failed">Google sign in failed: %1$s</string>
 
+    <!-- Requirements feature strings -->
+    <string name="requirements_enter_prompt">Please enter requirements</string>
+    <string name="requirements_generating">Generating...</string>
+    <string name="requirements_generate_code">Generate Code</string>
+    <string name="requirements_generate_success">Code generated successfully!</string>
+    <string name="requirements_error">Error: %1$s</string>
+    <string name="requirements_assess_complexity">Assess Complexity</string>
+
 </resources>


### PR DESCRIPTION
## Summary
- move requirements fragment and layout to debug source set
- gate sample requirements loading behind BuildConfig.DEBUG
- externalize requirements UI strings to resources

## Testing
- `./gradlew test` *(fails: Build was configured to prefer settings repositories over project repositories but repository 'Google' was added)*

------
https://chatgpt.com/codex/tasks/task_e_688e14787290832496e630bc4e39f34c