### PR TITLE
Integrate dialog for adding activities

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/ui/activities/ActivitiesFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/ui/activities/ActivitiesFragment.kt
@@ -73,7 +73,8 @@ class ActivitiesFragment : Fragment() {
     }
 
     private fun showAddActivityDialog() {
-        EditActivityDialog(requireContext()) { activity ->
+        val dialog = CreateNewActivityDialog()
+        dialog.setOnActivityCreatedListener { activity ->
             lifecycleScope.launch {
                 try {
                     dataRepository.insertActivity(activity.toEntity())
@@ -90,7 +91,8 @@ class ActivitiesFragment : Fragment() {
                     ).show()
                 }
             }
-        }.show()
+        }
+        dialog.show(parentFragmentManager, "CreateNewActivityDialog")
     }
 
     private fun onActivityClick(activity: Activity) {


### PR DESCRIPTION
## Summary
- Replace Add Activity placeholder toast with a dialog that creates and saves activities through `DataRepository`
- Ensure success and error messages use existing string resources

## Testing
- `./gradlew test` *(fails: Build was configured to prefer settings repositories over project repositories but repository 'Google' was added by build file 'build.gradle.kts')*


------
https://chatgpt.com/codex/tasks/task_e_688e1b675ea08324a990b06f93f4e3d3