### PR TITLE
Guard sample data generation for release

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/calendar/CalendarFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/calendar/CalendarFragment.kt
@@ -117,18 +117,14 @@ class CalendarFragment : Fragment(R.layout.fragment_calendar) {
             val nextWeek = todayStart + (7 * 24 * 60 * 60 * 1000)
             
             val existingEvents = database.calendarEventDao().getEventsForDay(todayStart, nextWeek)
-            
+
             // If no events exist, optionally create sample data in debug builds
-            if (existingEvents.isEmpty()) {
-                if (BuildConfig.DEBUG) {
-                    val sampleEvents = energyManager.createSampleTodayData()
-                    sampleEvents.forEach { event ->
-                        database.calendarEventDao().insertEvent(event)
-                    }
-                    allEvents = sampleEvents
-                } else {
-                    allEvents = existingEvents
+            if (existingEvents.isEmpty() && BuildConfig.DEBUG) {
+                val sampleEvents = energyManager.createSampleTodayData()
+                sampleEvents.forEach { event ->
+                    database.calendarEventDao().insertEvent(event)
                 }
+                allEvents = sampleEvents
             } else {
                 allEvents = existingEvents
             }

--- a/app/src/main/java/com/example/socialbatterymanager/features/energy/EnergyManager.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/energy/EnergyManager.kt
@@ -114,37 +114,37 @@ class EnergyManager {
      * Create sample data for today to demonstrate the energy tracking
      */
     fun createSampleTodayData(): List<CalendarEvent> {
-        if (!BuildConfig.DEBUG) return emptyList()
-
-        val todayStart = getTodayStart()
-        val sampleEvents = listOf(
-            CalendarEvent(
-                id = 1,
-                title = "Team Meeting",
-                description = "Weekly standup with development team",
-                startTime = todayStart + (9 * 60 * 60 * 1000), // 9:00 AM
-                endTime = todayStart + (10.5 * 60 * 60 * 1000), // 10:30 AM
-                source = "google"
-            ),
-            CalendarEvent(
-                id = 2,
-                title = "Lunch with Sarah",
-                description = "Catching up with close friend",
-                startTime = todayStart + (12 * 60 * 60 * 1000), // 12:00 PM
-                endTime = todayStart + (13 * 60 * 60 * 1000), // 1:00 PM
-                source = "manual"
-            ),
-            CalendarEvent(
-                id = 3,
-                title = "Client Presentation",
-                description = "Important project presentation",
-                startTime = todayStart + (15 * 60 * 60 * 1000), // 3:00 PM
-                endTime = todayStart + (16.5 * 60 * 60 * 1000), // 4:30 PM
-                source = "outlook"
+        if (BuildConfig.DEBUG) {
+            val todayStart = getTodayStart()
+            val sampleEvents = listOf(
+                CalendarEvent(
+                    id = 1,
+                    title = "Team Meeting",
+                    description = "Weekly standup with development team",
+                    startTime = todayStart + (9 * 60 * 60 * 1000), // 9:00 AM
+                    endTime = todayStart + (10.5 * 60 * 60 * 1000), // 10:30 AM
+                    source = "google",
+                ),
+                CalendarEvent(
+                    id = 2,
+                    title = "Lunch with Sarah",
+                    description = "Catching up with close friend",
+                    startTime = todayStart + (12 * 60 * 60 * 1000), // 12:00 PM
+                    endTime = todayStart + (13 * 60 * 60 * 1000), // 1:00 PM
+                    source = "manual",
+                ),
+                CalendarEvent(
+                    id = 3,
+                    title = "Client Presentation",
+                    description = "Important project presentation",
+                    startTime = todayStart + (15 * 60 * 60 * 1000), // 3:00 PM
+                    endTime = todayStart + (16.5 * 60 * 60 * 1000), // 4:30 PM
+                    source = "outlook",
+                )
             )
-        )
-
-        return sampleEvents
+            return sampleEvents
+        }
+        return emptyList()
     }
     
     private fun getTodayStart(currentTime: Long = System.currentTimeMillis()): Long {

--- a/app/src/main/java/com/example/socialbatterymanager/features/notifications/NotificationService.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/notifications/NotificationService.kt
@@ -17,38 +17,39 @@ class NotificationService(private val context: Context) {
     private val scope = CoroutineScope(Dispatchers.IO)
     
     fun generateSampleNotifications() {
-        if (!BuildConfig.DEBUG) return
-        scope.launch {
-            // Retrieve current notifications to avoid duplicate inserts
-            val existingNotifications =
-                database.notificationDao().getAllNotifications().first()
+        if (BuildConfig.DEBUG) {
+            scope.launch {
+                // Retrieve current notifications to avoid duplicate inserts
+                val existingNotifications =
+                    database.notificationDao().getAllNotifications().first()
 
-            if (existingNotifications.isEmpty()) {
-                // Generate sample notifications only when none exist
-                val notifications = listOf(
-                    NotificationEntity(
-                        type = NotificationType.ENERGY_LOW.name,
-                        title = context.getString(R.string.notification_energy_low_title),
-                        message = context.getString(R.string.notification_energy_low_sample_message),
-                        timestamp = System.currentTimeMillis() - (2 * 60 * 1000) // 2 minutes ago
-                    ),
-                    NotificationEntity(
-                        type = NotificationType.BUSY_WEEK.name,
-                        title = context.getString(R.string.notification_busy_week_title),
-                        message = context.getString(R.string.notification_busy_week_sample_message),
-                        timestamp = System.currentTimeMillis() - (60 * 60 * 1000) // 1 hour ago
-                    ),
-                    NotificationEntity(
-                        type = NotificationType.RATE_ACTIVITY.name,
-                        title = context.getString(R.string.notification_rate_activity_title),
-                        message = context.getString(R.string.notification_rate_activity_sample_message),
-                        timestamp = System.currentTimeMillis() - (3 * 60 * 60 * 1000), // 3 hours ago
-                        activityId = 1 // Assuming there's an activity with ID 1
+                if (existingNotifications.isEmpty()) {
+                    // Generate sample notifications only when none exist
+                    val notifications = listOf(
+                        NotificationEntity(
+                            type = NotificationType.ENERGY_LOW.name,
+                            title = context.getString(R.string.notification_energy_low_title),
+                            message = context.getString(R.string.notification_energy_low_sample_message),
+                            timestamp = System.currentTimeMillis() - (2 * 60 * 1000) // 2 minutes ago
+                        ),
+                        NotificationEntity(
+                            type = NotificationType.BUSY_WEEK.name,
+                            title = context.getString(R.string.notification_busy_week_title),
+                            message = context.getString(R.string.notification_busy_week_sample_message),
+                            timestamp = System.currentTimeMillis() - (60 * 60 * 1000) // 1 hour ago
+                        ),
+                        NotificationEntity(
+                            type = NotificationType.RATE_ACTIVITY.name,
+                            title = context.getString(R.string.notification_rate_activity_title),
+                            message = context.getString(R.string.notification_rate_activity_sample_message),
+                            timestamp = System.currentTimeMillis() - (3 * 60 * 60 * 1000), // 3 hours ago
+                            activityId = 1 // Assuming there's an activity with ID 1
+                        )
                     )
-                )
 
-                notifications.forEach { notification ->
-                    database.notificationDao().insertNotification(notification)
+                    notifications.forEach { notification ->
+                        database.notificationDao().insertNotification(notification)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- ensure notification sample data is only generated in debug builds
- restrict energy sample events to debug mode
- create calendar sample events only when debugging

## Testing
- `./gradlew test` *(fails: Build was configured to prefer settings repositories over project repositories but repository 'Google' was added by build file 'build.gradle.kts')*


------
https://chatgpt.com/codex/tasks/task_e_688e1b689bd883249304686bcbb4c1b7