### PR TITLE
Remove Google/Teams calendar API placeholders

### DIFF
--- a/CALENDAR_README.md
+++ b/CALENDAR_README.md
@@ -10,14 +10,14 @@ The calendar feature allows users to:
 - Create manual events
 - Store events locally in Room database
 - View events for selected dates
-- Direct integrations with Google Calendar and Microsoft Teams are not yet implemented
+- Only the device's local calendar is supported; direct integrations with services like Google Calendar or Microsoft Teams are not available
 
 ## Files Implemented
 
 ### Core Files
 - `calendar/CalendarFragment.kt` - Main calendar fragment with UI logic
 - `calendar/CalendarAdapter.kt` - RecyclerView adapter for displaying events
-- `calendar/CalendarIntegration.kt` - Integration with external calendars
+- `calendar/CalendarIntegration.kt` - Integration with the device calendar
 - `data/CalendarEvent.kt` - Room entity for calendar events
 - `data/CalendarEventDao.kt` - Room DAO for calendar operations
 
@@ -48,13 +48,13 @@ The calendar feature allows users to:
 ### 3. Event Import
 - Device calendar integration
 - Permission handling for READ_CALENDAR
-- Source detection for Google, Teams, Outlook calendars based on calendar name
-- Direct API integrations for Google Calendar and Microsoft Teams are not yet available
+- Imported events are tagged as coming from the device calendar
+- Direct API integrations for services like Google Calendar or Microsoft Teams are not supported
 
 ### 4. Event Display
 - RecyclerView showing events for selected date
 - Time formatting (HH:mm)
-- Source badges (Google, Teams, Manual, etc.)
+- Source badges (Device, Manual)
 - Event descriptions (when available)
 
 ### 5. Manual Event Creation

--- a/app/src/main/java/com/example/socialbatterymanager/data/database/CalendarEventDao.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/data/database/CalendarEventDao.kt
@@ -29,9 +29,6 @@ interface CalendarEventDao {
     @Query("SELECT * FROM calendar_events WHERE startTime >= :startTime AND startTime < :endTime ORDER BY startTime ASC")
     suspend fun getEventsForDay(startTime: Long, endTime: Long): List<CalendarEvent>
     
-    @Query("SELECT * FROM calendar_events WHERE source = :source")
-    suspend fun getEventsBySource(source: String): List<CalendarEvent>
-    
-    @Query("DELETE FROM calendar_events WHERE source = :source")
-    suspend fun deleteEventsBySource(source: String)
+    @Query("DELETE FROM calendar_events WHERE isImported = 1")
+    suspend fun deleteImportedEvents()
 }

--- a/app/src/main/java/com/example/socialbatterymanager/data/model/CalendarEvent.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/data/model/CalendarEvent.kt
@@ -11,7 +11,7 @@ data class CalendarEvent(
     val startTime: Long,
     val endTime: Long,
     val location: String = "",
-    val source: String = "", // "google", "teams", "manual"
+    val source: String = "", // "device" for imported events, "manual" for user-created
     val externalId: String = "", // ID from external calendar
     val isImported: Boolean = false
 )


### PR DESCRIPTION
## Summary
- Clarify that only local device calendars are supported
- Remove unused Google/Teams calendar API stubs and related DAO methods
- Update documentation and data model to reflect local calendar support

## Testing
- `./gradlew test` *(fails: Build was configured to prefer settings repositories over project repositories but repository 'Google' was added by build file 'build.gradle.kts')*

------
https://chatgpt.com/codex/tasks/task_e_688e1b6905e883249a9a095f9dec55b5