### PR TITLE
Refactor inline messages into string resources

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/calendar/CalendarFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/calendar/CalendarFragment.kt
@@ -143,10 +143,10 @@ class CalendarFragment : Fragment(R.layout.fragment_calendar) {
         
         // Update energy dashboard
         energyProgressBar.progress = energyState.currentEnergyLevel
-        tvEnergyPercentage.text = "${energyState.currentEnergyLevel}%"
-        tvRemainingHours.text = String.format("%.1fh", energyState.remainingHours)
+        tvEnergyPercentage.text = getString(R.string.percent_format, energyState.currentEnergyLevel)
+        tvRemainingHours.text = getString(R.string.hours_format, energyState.remainingHours)
         tvActivitiesCount.text = energyState.activitiesCount.toString()
-        tvPlannedHours.text = String.format("%.1fh", energyState.plannedHours)
+        tvPlannedHours.text = getString(R.string.hours_format, energyState.plannedHours)
     }
     
     private fun loadEventsForSelectedDate() {

--- a/app/src/main/java/com/example/socialbatterymanager/shared/utils/ErrorHandler.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/shared/utils/ErrorHandler.kt
@@ -107,8 +107,8 @@ object ErrorHandler {
             is java.net.UnknownHostException,
             is java.net.SocketTimeoutException,
             is java.net.ConnectException -> context.getString(R.string.error_network)
-            is SecurityException -> "Permission denied"
-            is IllegalArgumentException -> "Invalid input"
+            is SecurityException -> context.getString(R.string.permission_denied)
+            is IllegalArgumentException -> context.getString(R.string.invalid_input)
             else -> context.getString(R.string.error_general)
         }
         

--- a/app/src/main/java/com/example/socialbatterymanager/ui/activities/CreateNewActivityDialog.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/ui/activities/CreateNewActivityDialog.kt
@@ -82,7 +82,7 @@ class CreateNewActivityDialog : DialogFragment() {
 
     private fun setupViews() {
         // Setup activity type spinner
-        val activityTypes = arrayOf("Work", "Leisure", "Other")
+        val activityTypes = resources.getStringArray(R.array.activity_types)
         val adapter = ArrayAdapter(requireContext(), android.R.layout.simple_spinner_item, activityTypes)
         adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
         spinnerActivityType.adapter = adapter
@@ -173,19 +173,20 @@ class CreateNewActivityDialog : DialogFragment() {
     }
 
     private fun showAddPersonDialog() {
-        val editText = EditText(requireContext())
-        editText.hint = "Enter person's name"
-        
+        val editText = EditText(requireContext()).apply {
+            hint = getString(R.string.enter_person_name_hint)
+        }
+
         android.app.AlertDialog.Builder(requireContext())
-            .setTitle("Add Person")
+            .setTitle(getString(R.string.add_person))
             .setView(editText)
-            .setPositiveButton("Add") { _, _ ->
+            .setPositiveButton(getString(R.string.add)) { _, _ ->
                 val personName = editText.text.toString().trim()
                 if (personName.isNotEmpty()) {
                     addPersonToActivity(personName)
                 }
             }
-            .setNegativeButton("Cancel", null)
+            .setNegativeButton(getString(R.string.cancel), null)
             .show()
     }
 
@@ -263,7 +264,7 @@ class CreateNewActivityDialog : DialogFragment() {
         
         if (projectedUsage > weeklyTarget * 0.9) { // 90% of target
             val remainingCapacity = ((weeklyTarget - projectedUsage).toFloat() / weeklyTarget * 100).toInt()
-            tvWeeklyCapacityMessage.text = "This activity will bring your weekly capacity down to $remainingCapacity%. You may want to reschedule or reduce intensity."
+            tvWeeklyCapacityMessage.text = getString(R.string.weekly_capacity_warning, remainingCapacity)
             layoutWeeklyCapacityWarning.visibility = View.VISIBLE
         } else {
             layoutWeeklyCapacityWarning.visibility = View.GONE
@@ -284,7 +285,7 @@ class CreateNewActivityDialog : DialogFragment() {
         val description = etActivityDescription.text.toString().trim()
         
         if (name.isEmpty()) {
-            Toast.makeText(requireContext(), "Please enter an activity name", Toast.LENGTH_SHORT).show()
+            Toast.makeText(requireContext(), getString(R.string.error_activity_name_required), Toast.LENGTH_SHORT).show()
             return
         }
         

--- a/app/src/main/res/layout/dialog_create_new_activity.xml
+++ b/app/src/main/res/layout/dialog_create_new_activity.xml
@@ -112,7 +112,7 @@
             style="@style/Widget.Material3.Button.TextButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="+ Add Person"
+            android:text="@string/add_person_button"
             android:textColor="@color/jscc_charcoal"
             android:layout_marginBottom="20dp" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,20 @@
     <string name="activity_delete_error">Error deleting activity: %1$s</string>
     <string name="activity_marked_as_used">Activity marked as used!</string>
     <string name="activity_usage_error">Error updating usage: %1$s</string>
+    <string name="error_activity_name_required">Please enter an activity name</string>
+    <string name="weekly_capacity_warning">This activity will bring your weekly capacity down to %1$d%%. You may want to reschedule or reduce intensity.</string>
+    <string name="enter_person_name_hint">Enter person's name</string>
+    <string name="add">Add</string>
+    <string name="hours_format">%.1fh</string>
+
+    <string-array name="activity_types">
+        <item>@string/activity_type_work</item>
+        <item>@string/activity_type_leisure</item>
+        <item>@string/activity_type_other</item>
+    </string-array>
+    <string name="activity_type_work">Work</string>
+    <string name="activity_type_leisure">Leisure</string>
+    <string name="activity_type_other">Other</string>
     <string name="calendar_title">Calendar</string>
     <string name="add_to_calendar">+ Create New Activity</string>
     <string name="import_events">Import Events</string>
@@ -41,6 +55,7 @@
 
     <!-- People -->
     <string name="add_person">Add Person</string>
+    <string name="add_person_button">+ Add Person</string>
     <string name="edit_person">Edit Person</string>
     <string name="error_name_required">Name is required</string>
     <string name="imported_from_contacts">Imported from contacts</string>
@@ -125,6 +140,7 @@
     <string name="error_network">Network error. Please check your connection.</string>
     <string name="error_offline">You are offline. Some features may not be available.</string>
     <string name="retry">Retry</string>
+    <string name="invalid_input">Invalid input</string>
     
     <!-- Biometric strings -->
     <string name="biometric_title">Authenticate</string>

--- a/app/src/test/java/com/example/socialbatterymanager/ResourceStringsTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/ResourceStringsTest.kt
@@ -1,0 +1,20 @@
+package com.example.socialbatterymanager
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ResourceStringsTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun permissionDeniedStringMatches() {
+        assertEquals("Permission denied", context.getString(R.string.permission_denied))
+    }
+
+    @Test
+    fun addPersonStringMatches() {
+        assertEquals("Add Person", context.getString(R.string.add_person))
+    }
+}


### PR DESCRIPTION
## Summary
- externalize activity dialog messages and labels into string resources
- format energy dashboard values and errors using resource strings
- add basic tests confirming new resource IDs

## Testing
- `./gradlew test` *(fails: Build was configured to prefer settings repositories over project repositories but repository 'Google' was added by build file 'build.gradle.kts')*

------
https://chatgpt.com/codex/tasks/task_e_688e1b6825dc8324968d143d3a3a352e