### PR TITLE
Externalize AddActivityDialog strings

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/features/home/ui/AddActivityDialog.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/home/ui/AddActivityDialog.kt
@@ -45,9 +45,14 @@ class AddActivityDialog(
         }
 
         val dialog = AlertDialog.Builder(context)
-            .setTitle(if (existingActivity == null) "Add Activity" else "Edit Activity")
+            .setTitle(
+                if (existingActivity == null)
+                    context.getString(R.string.add_activity_title)
+                else
+                    context.getString(R.string.edit_activity_title)
+            )
             .setView(view)
-            .setPositiveButton("Save") { _, _ ->
+            .setPositiveButton(context.getString(R.string.save)) { _, _ ->
                 val name = etName.text.toString().trim()
                 val type = spinnerType.selectedItem.toString()
                 val energy = spinnerEnergy.selectedItem.toString().toIntOrNull() ?: 0
@@ -68,10 +73,14 @@ class AddActivityDialog(
                     )
                     onActivityAdded(activity)
                 } else {
-                    Toast.makeText(context, "Please enter an activity name", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(
+                        context,
+                        context.getString(R.string.error_activity_name_required),
+                        Toast.LENGTH_SHORT
+                    ).show()
                 }
             }
-            .setNegativeButton("Cancel", null)
+            .setNegativeButton(context.getString(R.string.cancel), null)
             .create()
 
         dialog.show()
@@ -83,20 +92,20 @@ class AddActivityDialog(
         moodSpinner: Spinner
     ) {
         // Activity types
-        val types = arrayOf("Work", "Social", "Exercise", "Hobby", "Rest", "Other")
+        val types = context.resources.getStringArray(R.array.activity_type_options)
         val typeAdapter = ArrayAdapter(context, android.R.layout.simple_spinner_item, types)
         typeAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
         typeSpinner.adapter = typeAdapter
 
         // Energy impact values
-        val energyValues = arrayOf("-5", "-4", "-3", "-2", "-1", "0", "1", "2", "3", "4", "5")
+        val energyValues = context.resources.getStringArray(R.array.energy_impact_values)
         val energyAdapter = ArrayAdapter(context, android.R.layout.simple_spinner_item, energyValues)
         energyAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
         energySpinner.adapter = energyAdapter
         energySpinner.setSelection(5) // Default to 0
 
         // Mood options
-        val moods = arrayOf("😊 Happy", "😐 Neutral", "😔 Sad", "😴 Tired", "😤 Stressed", "😎 Energetic")
+        val moods = context.resources.getStringArray(R.array.mood_dialog_options)
         val moodAdapter = ArrayAdapter(context, android.R.layout.simple_spinner_item, moods)
         moodAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
         moodSpinner.adapter = moodAdapter

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -8,4 +8,36 @@
         <item>😢 Sad</item>
         <!-- Add any other moods you like -->
     </string-array>
+
+    <string-array name="activity_type_options">
+        <item>Work</item>
+        <item>Social</item>
+        <item>Exercise</item>
+        <item>Hobby</item>
+        <item>Rest</item>
+        <item>Other</item>
+    </string-array>
+
+    <string-array name="energy_impact_values">
+        <item>-5</item>
+        <item>-4</item>
+        <item>-3</item>
+        <item>-2</item>
+        <item>-1</item>
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+    </string-array>
+
+    <string-array name="mood_dialog_options">
+        <item>😊 Happy</item>
+        <item>😐 Neutral</item>
+        <item>😔 Sad</item>
+        <item>😴 Tired</item>
+        <item>😤 Stressed</item>
+        <item>😎 Energetic</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,9 @@
     <string name="activities_title">Activities</string>
     <string name="activities_empty">No activities yet. Tap the + button to add one!</string>
     <string name="add_activity">+ Add Activity</string>
+    <string name="add_activity_title">Add Activity</string>
+    <string name="edit_activity_title">Edit Activity</string>
+    <string name="save">Save</string>
     <string name="activity_name">Activity Name</string>
     <string name="activity_type">Type</string>
     <string name="activity_energy">Energy</string>


### PR DESCRIPTION
## Summary
- move AddActivityDialog dialog titles, buttons, and spinner options into string/array resources
- replace inline literals with `getString(...)` and `resources.getStringArray(...)`

## Testing
- `./gradlew test` *(fails: Build was configured to prefer settings repositories over project repositories but repository 'Google' was added by build file 'build.gradle.kts')*


------
https://chatgpt.com/codex/tasks/task_e_688e1f7d3f0c8324a31973b3a6d46e2f