### PR TITLE
Refine energy dialogs and disable unfinished features

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/features/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/home/ui/HomeFragment.kt
@@ -263,15 +263,8 @@ class HomeFragment : Fragment() {
             dialog.show()
         }
 
-        btnPlanDay.setOnClickListener {
-            // Navigate to calendar or planning feature
-            // For now, show a simple message
-            AlertDialog.Builder(requireContext())
-                .setTitle("Plan Day")
-                .setMessage("Day planning feature coming soon!")
-                .setPositiveButton("OK", null)
-                .show()
-        }
+        // Disable unimplemented planning feature
+        btnPlanDay.isEnabled = false
 
         btnViewBattery.setOnClickListener {
             // Show detailed battery info
@@ -313,36 +306,31 @@ class HomeFragment : Fragment() {
     }
 
     private fun showBatteryDetails() {
-        val message = """
-            Current Energy: $currentEnergyLevel%
-            Energy Level: ${energyBatteryView.getEnergyLevelLabel()}
-            
-            Energy Ranges:
-            • 100-80%: High Energy
-            • 79-60%: Medium Energy  
-            • 59-30%: Low Energy
-            • 29-0%: Recharge
-        """.trimIndent()
-        
+        val message = getString(
+            R.string.battery_details_message,
+            currentEnergyLevel,
+            energyBatteryView.getEnergyLevelLabel()
+        )
+
         AlertDialog.Builder(requireContext())
-            .setTitle("Battery Details")
+            .setTitle(R.string.battery_details_title)
             .setMessage(message)
-            .setPositiveButton("OK", null)
+            .setPositiveButton(android.R.string.ok, null)
             .show()
     }
 
     private fun showEnergyTips() {
-        val tips = when {
-            currentEnergyLevel >= 80 -> "You're in great shape! Consider taking on social activities."
-            currentEnergyLevel >= 60 -> "Good energy levels. Balance social time with some rest."
-            currentEnergyLevel >= 30 -> "Energy is getting low. Consider lighter social activities."
-            else -> "Time to recharge! Take some alone time to restore your energy."
+        val tipsResId = when {
+            currentEnergyLevel >= 80 -> R.string.energy_tip_high
+            currentEnergyLevel >= 60 -> R.string.energy_tip_medium
+            currentEnergyLevel >= 30 -> R.string.energy_tip_low
+            else -> R.string.energy_tip_recharge
         }
-        
+
         AlertDialog.Builder(requireContext())
-            .setTitle("Energy Tips")
-            .setMessage(tips)
-            .setPositiveButton("OK", null)
+            .setTitle(R.string.energy_tips_title)
+            .setMessage(getString(tipsResId))
+            .setPositiveButton(android.R.string.ok, null)
             .show()
     }
 

--- a/app/src/main/java/com/example/socialbatterymanager/features/profile/ui/ProfileFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/profile/ui/ProfileFragment.kt
@@ -157,9 +157,8 @@ class ProfileFragment : Fragment() {
             showRecalibrationDialog()
         }
 
-        surveyButton.setOnClickListener {
-            showSurveyDialog()
-        }
+        // Disable survey feature until implemented
+        surveyButton.isEnabled = false
 
         privacySettingsButton.setOnClickListener {
             findNavController().navigate(R.id.action_profileFragment_to_privacySettingsFragment)
@@ -353,18 +352,6 @@ class ProfileFragment : Fragment() {
                 performRecalibration()
             }
             .setNegativeButton(getString(R.string.cancel), null)
-            .show()
-    }
-
-    private fun showSurveyDialog() {
-        AlertDialog.Builder(requireContext())
-            .setTitle(getString(R.string.survey_title))
-            .setMessage(getString(R.string.survey_message))
-            .setPositiveButton(getString(R.string.take_survey)) { _, _ ->
-                // In a real app, this would open a survey activity or web view
-                Toast.makeText(requireContext(), getString(R.string.survey_coming_soon), Toast.LENGTH_SHORT).show()
-            }
-            .setNegativeButton(getString(R.string.later), null)
             .show()
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,6 +96,24 @@
     <string name="energy_recommendation_low">Energy running low. Take breaks and avoid high-stress activities.</string>
     <string name="energy_recommendation_very_low">Very low energy. Consider rescheduling non-essential activities.</string>
     <string name="energy_warning_planned_exceed">Warning: Planned activities exceed available energy (%1$.1fh vs %2$.1fh)</string>
+
+    <!-- Battery details -->
+    <string name="battery_details_title">Battery Details</string>
+    <string name="battery_details_message">Current Energy: %1$d%%
+Energy Level: %2$s
+
+Energy Ranges:
+• 100-80%%: High Energy
+• 79-60%%: Medium Energy
+• 59-30%%: Low Energy
+• 29-0%%: Recharge</string>
+
+    <!-- Energy tips -->
+    <string name="energy_tips_title">Energy Tips</string>
+    <string name="energy_tip_high">You're in great shape! Consider taking on social activities.</string>
+    <string name="energy_tip_medium">Good energy levels. Balance social time with some rest.</string>
+    <string name="energy_tip_low">Energy is getting low. Consider lighter social activities.</string>
+    <string name="energy_tip_recharge">Time to recharge! Take some alone time to restore your energy.</string>
     
     <!-- Weekly Forecast -->
     <string name="weekly_forecast_title">Weekly Forecast</string>
@@ -212,7 +230,6 @@
     <string name="survey_message">Take a quick survey to help us better understand your social energy patterns and improve your experience.</string>
     <string name="take_survey">Take Survey</string>
     <string name="later">Later</string>
-    <string name="survey_coming_soon">Survey feature coming soon!</string>
     <string name="sign_out_success">Signed out successfully</string>
     <string name="account_deleted_success">Account deleted successfully</string>
     <string name="battery_recalibrated_success">Battery recalibrated successfully</string>


### PR DESCRIPTION
## Summary
- Replace hardcoded energy dialog strings with localized resources
- Disable unimplemented planning and survey features
- Add string resources for battery details and energy tips

## Testing
- `./gradlew test` *(fails: Build was configured to prefer settings repositories over project repositories)*

------
https://chatgpt.com/codex/tasks/task_e_688e1f7d93908324ac380b2a6f60345f