### PR TITLE
refactor: externalize privacy strings

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/features/privacy/ui/PrivacySettingsFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/privacy/ui/PrivacySettingsFragment.kt
@@ -172,7 +172,11 @@ class PrivacySettingsFragment : Fragment() {
                 preferences[ACTIVITY_PATTERNS_ENABLED_KEY] = activityPatternsSwitch.isChecked
             }
 
-            Toast.makeText(requireContext(), "Privacy settings updated", Toast.LENGTH_SHORT).show()
+            Toast.makeText(
+                requireContext(),
+                getString(R.string.privacy_settings_updated),
+                Toast.LENGTH_SHORT
+            ).show()
         }
     }
 
@@ -182,31 +186,40 @@ class PrivacySettingsFragment : Fragment() {
         val emailEditText = dialogView.findViewById<EditText>(R.id.emailEditText)
 
         AlertDialog.Builder(requireContext())
-            .setTitle("Block User")
-            .setMessage("Enter the user details to block them from seeing your mood and energy")
+            .setTitle(getString(R.string.block_user_title))
+            .setMessage(getString(R.string.block_user_message))
             .setView(dialogView)
-            .setPositiveButton("Block") { _, _ ->
+            .setPositiveButton(getString(R.string.block)) { _, _ ->
                 val name = nameEditText.text.toString().trim()
                 val email = emailEditText.text.toString().trim()
-                
+
                 if (name.isNotEmpty()) {
                     addBlockedUser(name, email)
                 } else {
-                    Toast.makeText(requireContext(), "Please enter a name", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(
+                        requireContext(),
+                        getString(R.string.please_enter_name),
+                        Toast.LENGTH_SHORT
+                    ).show()
                 }
             }
-            .setNegativeButton("Cancel", null)
+            .setNegativeButton(getString(R.string.cancel), null)
             .show()
     }
 
     private fun showRemoveUserDialog(blockedUser: BlockedUser) {
         AlertDialog.Builder(requireContext())
-            .setTitle("Remove Blocked User")
-            .setMessage("Are you sure you want to remove ${blockedUser.blockedUserName} from blocked users? They will be able to see your mood and energy again.")
-            .setPositiveButton("Remove") { _, _ ->
+            .setTitle(getString(R.string.remove_blocked_user_title))
+            .setMessage(
+                getString(
+                    R.string.remove_blocked_user_message,
+                    blockedUser.blockedUserName
+                )
+            )
+            .setPositiveButton(getString(R.string.remove)) { _, _ ->
                 removeBlockedUser(blockedUser)
             }
-            .setNegativeButton("Cancel", null)
+            .setNegativeButton(getString(R.string.cancel), null)
             .show()
     }
 
@@ -222,7 +235,11 @@ class PrivacySettingsFragment : Fragment() {
         blockedUsersAdapter.notifyItemInserted(blockedUsers.size - 1)
         
         // In real app, save to database
-        Toast.makeText(requireContext(), "$name has been blocked", Toast.LENGTH_SHORT).show()
+        Toast.makeText(
+            requireContext(),
+            getString(R.string.blocked_user_added, name),
+            Toast.LENGTH_SHORT
+        ).show()
     }
 
     private fun removeBlockedUser(blockedUser: BlockedUser) {
@@ -232,7 +249,14 @@ class PrivacySettingsFragment : Fragment() {
             blockedUsersAdapter.notifyItemRemoved(position)
             
             // In real app, remove from database
-            Toast.makeText(requireContext(), "${blockedUser.blockedUserName} has been unblocked", Toast.LENGTH_SHORT).show()
+            Toast.makeText(
+                requireContext(),
+                getString(
+                    R.string.blocked_user_removed,
+                    blockedUser.blockedUserName
+                ),
+                Toast.LENGTH_SHORT
+            ).show()
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -217,6 +217,18 @@
     <string name="account_deleted_success">Account deleted successfully</string>
     <string name="battery_recalibrated_success">Battery recalibrated successfully</string>
 
+    <!-- Privacy settings strings -->
+    <string name="privacy_settings_updated">Privacy settings updated</string>
+    <string name="block_user_title">Block User</string>
+    <string name="block_user_message">Enter the user details to block them from seeing your mood and energy</string>
+    <string name="block">Block</string>
+    <string name="please_enter_name">Please enter a name</string>
+    <string name="remove_blocked_user_title">Remove Blocked User</string>
+    <string name="remove_blocked_user_message">Are you sure you want to remove %1$s from blocked users? They will be able to see your mood and energy again.</string>
+    <string name="remove">Remove</string>
+    <string name="blocked_user_added">%1$s has been blocked</string>
+    <string name="blocked_user_removed">%1$s has been unblocked</string>
+
     <!-- Notification strings -->
     <string name="notification_energy_low_title">Energy Running Low</string>
     <string name="notification_energy_low_message">Your social energy is at %1$d%%. Consider taking a break!</string>


### PR DESCRIPTION
## Summary
- externalize user-visible strings in `PrivacySettingsFragment`
- reference string resources for dialog and toast text

## Testing
- `./gradlew test` *(fails: Build was configured to prefer settings repositories over project repositories but repository 'Google' was added)*

------
https://chatgpt.com/codex/tasks/task_e_688e1f7e304083248e8e295aff362034