### PR TITLE
Hide unfinished buttons in release builds

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/features/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/home/ui/HomeFragment.kt
@@ -24,6 +24,7 @@ import com.example.socialbatterymanager.data.model.ActivityEntity
 import com.example.socialbatterymanager.data.database.AppDatabase
 import com.example.socialbatterymanager.data.model.EnergyLog
 import com.example.socialbatterymanager.notification.EnergyReminderWorker
+import com.example.socialbatterymanager.BuildConfig
 import com.google.android.material.chip.Chip
 import com.google.android.material.chip.ChipGroup
 import com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -263,8 +264,12 @@ class HomeFragment : Fragment() {
             dialog.show()
         }
 
-        // Disable unimplemented planning feature
-        btnPlanDay.isEnabled = false
+        // Hide planning feature in release builds until implemented
+        if (!BuildConfig.DEBUG) {
+            btnPlanDay.visibility = View.GONE
+        } else {
+            btnPlanDay.isEnabled = false
+        }
 
         btnViewBattery.setOnClickListener {
             // Show detailed battery info

--- a/app/src/main/java/com/example/socialbatterymanager/features/profile/ui/ProfileFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/profile/ui/ProfileFragment.kt
@@ -36,6 +36,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import com.example.socialbatterymanager.R
 import com.example.socialbatterymanager.data.model.User
+import com.example.socialbatterymanager.BuildConfig
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
@@ -157,8 +158,12 @@ class ProfileFragment : Fragment() {
             showRecalibrationDialog()
         }
 
-        // Disable survey feature until implemented
-        surveyButton.isEnabled = false
+        // Hide survey feature in release builds until implemented
+        if (!BuildConfig.DEBUG) {
+            surveyButton.visibility = View.GONE
+        } else {
+            surveyButton.isEnabled = false
+        }
 
         privacySettingsButton.setOnClickListener {
             findNavController().navigate(R.id.action_profileFragment_to_privacySettingsFragment)

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -449,7 +449,7 @@
                         android:layout_width="0dp"
                         android:layout_weight="1"
                         android:layout_height="wrap_content"
-                        android:text="📅 Plan Day"
+                        android:text="@string/plan_day"
                         android:textColor="@android:color/white"
                         android:backgroundTint="#2196F3"
                         android:layout_marginStart="8dp" />

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -220,7 +220,7 @@
             android:id="@+id/surveyButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Take Survey"
+            android:text="@string/take_survey"
             android:layout_marginBottom="24dp"
             style="@style/Widget.Material3.Button.OutlinedButton" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -138,6 +138,9 @@ Energy Ranges:
     <string name="average_energy">Average Energy</string>
     <string name="peak_day">Peak Day</string>
     <string name="recovery_needed">Recovery Needed</string>
+
+    <!-- Day Planning -->
+    <string name="plan_day">📅 Plan Day</string>
     
     <!-- Mood Options -->
     <string-array name="mood_options">


### PR DESCRIPTION
## Summary
- Hide day planning and survey buttons in release builds to avoid exposing unimplemented features
- Replace hardcoded labels with string resources, adding new `plan_day` entry

## Testing
- `./gradlew test` *(fails: Build was configured to prefer settings repositories over project repositories but repository 'Google' was added by build.gradle.kts)*

------
https://chatgpt.com/codex/tasks/task_e_688e240af73883249a52f6b88ee6bef1