### PR TITLE
Refactor hardcoded layout text into string resources

### DIFF
--- a/app/src/main/res/layout/dialog_edit_person.xml
+++ b/app/src/main/res/layout/dialog_edit_person.xml
@@ -29,7 +29,7 @@
                 android:id="@+id/btnChangeAvatar"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Change Photo"
+                android:text="@string/change_photo"
                 android:icon="@drawable/ic_camera" />
 
         </LinearLayout>
@@ -38,7 +38,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="16dp"
-            android:hint="Name*">
+            android:hint="@string/name_required">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etName"
@@ -52,7 +52,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="16dp"
-            android:hint="Email">
+            android:hint="@string/email">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etEmail"
@@ -66,7 +66,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="16dp"
-            android:hint="Phone">
+            android:hint="@string/phone">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etPhone"
@@ -80,7 +80,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="24dp"
-            android:hint="Notes">
+            android:hint="@string/notes">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etNotes"
@@ -102,14 +102,14 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="8dp"
-                android:text="Cancel"
+                android:text="@string/cancel"
                 style="@style/Widget.Material3.Button.TextButton" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btnSave"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Save" />
+                android:text="@string/save" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/dialog_rate_activity.xml
+++ b/app/src/main/res/layout/dialog_rate_activity.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
@@ -25,7 +26,7 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Rate Your Activity"
+            android:text="@string/rate_activity_title"
             android:textSize="20sp"
             android:textStyle="bold"
             android:textColor="@color/jscc_charcoal" />
@@ -36,7 +37,7 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="How draining was this activity?"
+        android:text="@string/rate_activity_question"
         android:textSize="16sp"
         android:textColor="@color/jscc_charcoal"
         android:layout_marginBottom="8dp" />
@@ -45,18 +46,18 @@
         android:id="@+id/tvActivityName"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Team Meeting (2:00 PM - 3:00 PM)"
+        android:textColor="@color/jscc_gold_start"
         android:textSize="18sp"
         android:textStyle="bold"
-        android:textColor="@color/jscc_gold_start"
-        android:layout_marginBottom="24dp" />
+        android:layout_marginBottom="24dp"
+        tools:text="Team Meeting (2:00 PM - 3:00 PM)" />
 
     <!-- Rating Scale -->
     <TextView
         android:id="@+id/tvRatingLabel"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="3 - Neutral"
+        android:text="@string/rating_label_neutral"
         android:textSize="16sp"
         android:textStyle="bold"
         android:textColor="@color/jscc_charcoal"
@@ -85,7 +86,7 @@
             android:layout_width="0dp"
             android:layout_weight="1"
             android:layout_height="wrap_content"
-            android:text="1\nVery\nDraining"
+            android:text="@string/rating_1_very_draining"
             android:textSize="10sp"
             android:textColor="@color/jscc_light_gray"
             android:textAlignment="center"
@@ -95,7 +96,7 @@
             android:layout_width="0dp"
             android:layout_weight="1"
             android:layout_height="wrap_content"
-            android:text="2\nDraining"
+            android:text="@string/rating_2_draining"
             android:textSize="10sp"
             android:textColor="@color/jscc_light_gray"
             android:textAlignment="center"
@@ -105,7 +106,7 @@
             android:layout_width="0dp"
             android:layout_weight="1"
             android:layout_height="wrap_content"
-            android:text="3\nNeutral"
+            android:text="@string/rating_3_neutral"
             android:textSize="10sp"
             android:textColor="@color/jscc_light_gray"
             android:textAlignment="center"
@@ -115,7 +116,7 @@
             android:layout_width="0dp"
             android:layout_weight="1"
             android:layout_height="wrap_content"
-            android:text="4\nEnergizing"
+            android:text="@string/rating_4_energizing"
             android:textSize="10sp"
             android:textColor="@color/jscc_light_gray"
             android:textAlignment="center"
@@ -125,7 +126,7 @@
             android:layout_width="0dp"
             android:layout_weight="1"
             android:layout_height="wrap_content"
-            android:text="5\nVery\nEnergizing"
+            android:text="@string/rating_5_very_energizing"
             android:textSize="10sp"
             android:textColor="@color/jscc_light_gray"
             android:textAlignment="center"
@@ -144,7 +145,7 @@
             android:id="@+id/btnSkip"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Skip"
+            android:text="@string/skip"
             android:textColor="@color/jscc_charcoal"
             android:background="@color/jscc_light_gray"
             android:layout_marginEnd="12dp"
@@ -156,7 +157,7 @@
             android:id="@+id/btnSubmitRating"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Submit Rating"
+            android:text="@string/submit_rating"
             android:textColor="@color/jscc_white"
             android:background="@color/jscc_gold_start"
             android:paddingHorizontal="20dp"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -2,6 +2,7 @@
 <ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="#F5F5F5">
@@ -26,7 +27,7 @@
                 android:layout_width="0dp"
                 android:layout_weight="1"
                 android:layout_height="wrap_content"
-                android:text="🔋 Social Energy"
+                android:text="@string/social_energy_header"
                 android:textSize="20sp"
                 android:textStyle="bold"
                 android:textColor="@android:color/white" />
@@ -55,7 +56,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Social Energy Level"
+                    android:text="@string/social_energy_level"
                     android:textSize="20sp"
                     android:textStyle="bold"
                     android:textColor="@android:color/black"
@@ -64,7 +65,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Current energy status"
+                    android:text="@string/current_energy_status"
                     android:textSize="14sp"
                     android:textColor="@android:color/darker_gray"
                     android:layout_marginBottom="16dp" />
@@ -87,10 +88,10 @@
                         android:id="@+id/tvEnergyPercentage"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="75%"
                         android:textSize="32sp"
                         android:textStyle="bold"
-                        android:textColor="#4CAF50" />
+                        android:textColor="#4CAF50"
+                        tools:text="75%" />
 
                     <LinearLayout
                         android:layout_width="0dp"
@@ -103,7 +104,7 @@
                             android:id="@+id/tvEnergyLabel"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="High Energy"
+                            android:text="@string/energy_level_high"
                             android:textSize="16sp"
                             android:textStyle="bold"
                             android:textColor="@android:color/black" />
@@ -111,9 +112,9 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="↗ +5% from yesterday"
                             android:textSize="12sp"
-                            android:textColor="#4CAF50" />
+                            android:textColor="#4CAF50"
+                            tools:text="↗ +5% from yesterday" />
 
                     </LinearLayout>
 
@@ -140,7 +141,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="How are you feeling?"
+                    android:text="@string/how_are_you_feeling"
                     android:textSize="18sp"
                     android:textStyle="bold"
                     android:textColor="@android:color/black"
@@ -206,7 +207,7 @@
                             <TextView
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:text="🔋 Remaining"
+                                android:text="@string/remaining_with_icon"
                                 android:textSize="12sp"
                                 android:textColor="@android:color/white" />
 
@@ -214,15 +215,15 @@
                                 android:id="@+id/tvRemainingHours"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:text="6.2h"
                                 android:textSize="16sp"
                                 android:textStyle="bold"
-                                android:textColor="@android:color/white" />
+                                android:textColor="@android:color/white"
+                                tools:text="6.2h" />
 
                             <TextView
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:text="Social energy left"
+                                android:text="@string/social_energy_left"
                                 android:textSize="10sp"
                                 android:textColor="@android:color/white" />
 
@@ -249,7 +250,7 @@
                             <TextView
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:text="⏱ Burn Rate"
+                                android:text="@string/burn_rate_with_icon"
                                 android:textSize="12sp"
                                 android:textColor="@android:color/white" />
 
@@ -257,15 +258,15 @@
                                 android:id="@+id/tvBurnRate"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:text="2.1h"
                                 android:textSize="16sp"
                                 android:textStyle="bold"
-                                android:textColor="@android:color/white" />
+                                android:textColor="@android:color/white"
+                                tools:text="2.1h" />
 
                             <TextView
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:text="Per social activity"
+                                android:text="@string/per_social_activity"
                                 android:textSize="10sp"
                                 android:textColor="@android:color/white" />
 
@@ -312,7 +313,7 @@
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="📊"
+                        android:text="@string/chart_icon"
                         android:textSize="16sp" />
 
                 </LinearLayout>
@@ -342,10 +343,10 @@
                             android:id="@+id/tvAverageEnergy"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="78%"
                             android:textSize="16sp"
                             android:textStyle="bold"
-                            android:textColor="#4CAF50" />
+                            android:textColor="#4CAF50"
+                            tools:text="78%" />
 
                     </LinearLayout>
 
@@ -368,10 +369,10 @@
                             android:id="@+id/tvPeakDay"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Saturday"
                             android:textSize="16sp"
                             android:textStyle="bold"
-                            android:textColor="#2196F3" />
+                            android:textColor="#2196F3"
+                            tools:text="Saturday" />
 
                     </LinearLayout>
 
@@ -393,10 +394,10 @@
                             android:id="@+id/tvRecoveryNeeded"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="2 days"
                             android:textSize="16sp"
                             android:textStyle="bold"
-                            android:textColor="#FF5722" />
+                            android:textColor="#FF5722"
+                            tools:text="2 days" />
 
                     </LinearLayout>
 
@@ -423,7 +424,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Quick Actions"
+                    android:text="@string/quick_actions"
                     android:textSize="18sp"
                     android:textStyle="bold"
                     android:textColor="@android:color/black"
@@ -439,7 +440,7 @@
                         android:layout_width="0dp"
                         android:layout_weight="1"
                         android:layout_height="wrap_content"
-                        android:text="➕ Log Activity"
+                        android:text="@string/log_activity"
                         android:textColor="@android:color/white"
                         android:backgroundTint="#4CAF50"
                         android:layout_marginEnd="8dp" />
@@ -449,7 +450,7 @@
                         android:layout_width="0dp"
                         android:layout_weight="1"
                         android:layout_height="wrap_content"
-                        android:text="📅 Plan Day"
+                        android:text="@string/plan_day"
                         android:textColor="@android:color/white"
                         android:backgroundTint="#2196F3"
                         android:layout_marginStart="8dp" />
@@ -467,7 +468,7 @@
                         android:layout_width="0dp"
                         android:layout_weight="1"
                         android:layout_height="wrap_content"
-                        android:text="🔍 View Battery"
+                        android:text="@string/view_battery"
                         android:textColor="@android:color/white"
                         android:backgroundTint="#9C27B0"
                         android:layout_marginEnd="8dp" />
@@ -477,7 +478,7 @@
                         android:layout_width="0dp"
                         android:layout_weight="1"
                         android:layout_height="wrap_content"
-                        android:text="💡 Get Tips"
+                        android:text="@string/get_tips"
                         android:textColor="@android:color/white"
                         android:backgroundTint="#FF9800"
                         android:layout_marginStart="8dp" />

--- a/app/src/main/res/layout/fragment_privacy_settings.xml
+++ b/app/src/main/res/layout/fragment_privacy_settings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:padding="16dp">
@@ -36,7 +37,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Mood &amp; Energy Privacy"
+                    android:text="@string/mood_energy_privacy_title"
                     android:textSize="20sp"
                     android:textStyle="bold"
                     android:textColor="@android:color/white" />
@@ -44,7 +45,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Control who can see your mood and energy levels. Your privacy matters."
+                    android:text="@string/mood_energy_privacy_description"
                     android:textSize="14sp"
                     android:textColor="@android:color/white"
                     android:alpha="0.9" />
@@ -57,7 +58,7 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Who can see your mood &amp; energy"
+            android:text="@string/who_can_see_mood_energy"
             android:textStyle="bold"
             android:textSize="18sp"
             android:layout_marginBottom="8dp" />
@@ -65,7 +66,7 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Choose who has access to view your emotional state and energy levels"
+            android:text="@string/who_can_see_mood_energy_description"
             android:textSize="14sp"
             android:textColor="@android:color/darker_gray"
             android:layout_marginBottom="16dp" />
@@ -103,14 +104,14 @@
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Everyone"
+                        android:text="@string/privacy_option_everyone"
                         android:textSize="16sp"
                         android:textStyle="bold" />
 
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Anyone can see your mood and energy"
+                        android:text="@string/privacy_option_everyone_desc"
                         android:textSize="12sp"
                         android:textColor="@android:color/darker_gray" />
 
@@ -151,14 +152,14 @@
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Friends Only"
+                        android:text="@string/privacy_option_friends_only"
                         android:textSize="16sp"
                         android:textStyle="bold" />
 
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Only your friends can see your status"
+                        android:text="@string/privacy_option_friends_only_desc"
                         android:textSize="12sp"
                         android:textColor="@android:color/darker_gray" />
 
@@ -199,14 +200,14 @@
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Close Friends"
+                        android:text="@string/privacy_option_close_friends"
                         android:textSize="16sp"
                         android:textStyle="bold" />
 
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Only close friends can see your mood"
+                        android:text="@string/privacy_option_close_friends_desc"
                         android:textSize="12sp"
                         android:textColor="@android:color/darker_gray" />
 
@@ -246,14 +247,14 @@
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Only Me"
+                        android:text="@string/privacy_option_only_me"
                         android:textSize="16sp"
                         android:textStyle="bold" />
 
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Keep your mood and energy private"
+                        android:text="@string/privacy_option_only_me_desc"
                         android:textSize="12sp"
                         android:textColor="@android:color/darker_gray" />
 
@@ -273,7 +274,7 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Specific Permissions"
+            android:text="@string/specific_permissions_title"
             android:textStyle="bold"
             android:textSize="18sp"
             android:layout_marginBottom="8dp" />
@@ -281,7 +282,7 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Customize what information is visible to different groups"
+            android:text="@string/specific_permissions_description"
             android:textSize="14sp"
             android:textColor="@android:color/darker_gray"
             android:layout_marginBottom="16dp" />
@@ -311,14 +312,14 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Mood Status"
+                    android:text="@string/mood_status"
                     android:textSize="16sp"
                     android:textStyle="bold" />
 
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Allow others to see your current mood"
+                    android:text="@string/mood_status_description"
                     android:textSize="12sp"
                     android:textColor="@android:color/darker_gray" />
 
@@ -358,14 +359,14 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Energy Level"
+                    android:text="@string/energy_level_label"
                     android:textSize="16sp"
                     android:textStyle="bold" />
 
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Allow others to see your energy levels"
+                    android:text="@string/energy_level_description"
                     android:textSize="12sp"
                     android:textColor="@android:color/darker_gray" />
 
@@ -405,14 +406,14 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Activity Patterns"
+                    android:text="@string/activity_patterns"
                     android:textSize="16sp"
                     android:textStyle="bold" />
 
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Share your mood and energy patterns over time"
+                    android:text="@string/activity_patterns_description"
                     android:textSize="12sp"
                     android:textColor="@android:color/darker_gray" />
 
@@ -438,7 +439,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:text="Blocked Users"
+                android:text="@string/blocked_users"
                 android:textStyle="bold"
                 android:textSize="18sp" />
 
@@ -446,7 +447,7 @@
                 android:id="@+id/addUserButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="+ Add User"
+                android:text="@string/add_user"
                 android:textSize="12sp"
                 style="@style/Widget.Material3.Button.TonalButton" />
 
@@ -455,7 +456,7 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Users who cannot see your mood and energy"
+            android:text="@string/blocked_users_description"
             android:textSize="14sp"
             android:textColor="@android:color/darker_gray"
             android:layout_marginBottom="16dp" />
@@ -497,16 +498,16 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="John Smith"
                     android:textSize="16sp"
-                    android:textStyle="bold" />
+                    android:textStyle="bold"
+                    tools:text="John Smith" />
 
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@johnsmith"
                     android:textSize="12sp"
-                    android:textColor="@android:color/darker_gray" />
+                    android:textColor="@android:color/darker_gray"
+                    tools:text="@johnsmith" />
 
             </LinearLayout>
 
@@ -548,7 +549,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Privacy Tips"
+                    android:text="@string/privacy_tips"
                     android:textSize="16sp"
                     android:textStyle="bold"
                     android:textColor="@color/blue_700"
@@ -557,7 +558,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="• You can change these settings anytime"
+                    android:text="@string/privacy_tip_change_anytime"
                     android:textSize="12sp"
                     android:textColor="@color/blue_600"
                     android:layout_marginBottom="2dp" />
@@ -565,7 +566,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="• Blocked users won't be notified"
+                    android:text="@string/privacy_tip_blocked_not_notified"
                     android:textSize="12sp"
                     android:textColor="@color/blue_600"
                     android:layout_marginBottom="2dp" />
@@ -573,7 +574,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="• Close friends list can be managed in Friends settings"
+                    android:text="@string/privacy_tip_close_friends_manage"
                     android:textSize="12sp"
                     android:textColor="@color/blue_600" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -301,6 +301,70 @@ Energy Ranges:
     <string name="export_csv_title">Export CSV</string>
     <string name="export_report_title">Export Report</string>
     <string name="chart_energy_trends_over_time">Energy Trends Over Time</string>
-    <string name="chart_mood_distribution">Mood Distribution</string>
+<string name="chart_mood_distribution">Mood Distribution</string>
+
+    <!-- dialog_edit_person -->
+    <string name="change_photo">Change Photo</string>
+    <string name="name_required">Name*</string>
+    <string name="email">Email</string>
+    <string name="phone">Phone</string>
+    <string name="notes">Notes</string>
+    <string name="cancel">Cancel</string>
+
+    <!-- dialog_rate_activity -->
+    <string name="rate_activity_title">Rate Your Activity</string>
+    <string name="rate_activity_question">How draining was this activity?</string>
+    <string name="rating_label_neutral">3 - Neutral</string>
+    <string name="rating_1_very_draining">1\nVery\nDraining</string>
+    <string name="rating_2_draining">2\nDraining</string>
+    <string name="rating_3_neutral">3\nNeutral</string>
+    <string name="rating_4_energizing">4\nEnergizing</string>
+    <string name="rating_5_very_energizing">5\nVery\nEnergizing</string>
+    <string name="submit_rating">Submit Rating</string>
+
+    <!-- fragment_home -->
+    <string name="social_energy_header">🔋 Social Energy</string>
+    <string name="social_energy_level">Social Energy Level</string>
+    <string name="current_energy_status">Current energy status</string>
+    <string name="how_are_you_feeling">How are you feeling?</string>
+    <string name="remaining_with_icon">🔋 Remaining</string>
+    <string name="social_energy_left">Social energy left</string>
+    <string name="burn_rate_with_icon">⏱ Burn Rate</string>
+    <string name="per_social_activity">Per social activity</string>
+    <string name="quick_actions">Quick Actions</string>
+    <string name="log_activity">➕ Log Activity</string>
+    <string name="plan_day">📅 Plan Day</string>
+    <string name="view_battery">🔍 View Battery</string>
+    <string name="get_tips">💡 Get Tips</string>
+    <string name="chart_icon">📊</string>
+
+    <!-- fragment_privacy_settings -->
+    <string name="mood_energy_privacy_title">Mood &amp; Energy Privacy</string>
+    <string name="mood_energy_privacy_description">Control who can see your mood and energy levels. Your privacy matters.</string>
+    <string name="who_can_see_mood_energy">Who can see your mood &amp; energy</string>
+    <string name="who_can_see_mood_energy_description">Choose who has access to view your emotional state and energy levels</string>
+    <string name="privacy_option_everyone">Everyone</string>
+    <string name="privacy_option_everyone_desc">Anyone can see your mood and energy</string>
+    <string name="privacy_option_friends_only">Friends Only</string>
+    <string name="privacy_option_friends_only_desc">Only your friends can see your status</string>
+    <string name="privacy_option_close_friends">Close Friends</string>
+    <string name="privacy_option_close_friends_desc">Only close friends can see your mood</string>
+    <string name="privacy_option_only_me">Only Me</string>
+    <string name="privacy_option_only_me_desc">Keep your mood and energy private</string>
+    <string name="specific_permissions_title">Specific Permissions</string>
+    <string name="specific_permissions_description">Customize what information is visible to different groups</string>
+    <string name="mood_status">Mood Status</string>
+    <string name="mood_status_description">Allow others to see your current mood</string>
+    <string name="energy_level_label">Energy Level</string>
+    <string name="energy_level_description">Allow others to see your energy levels</string>
+    <string name="activity_patterns">Activity Patterns</string>
+    <string name="activity_patterns_description">Share your mood and energy patterns over time</string>
+    <string name="blocked_users">Blocked Users</string>
+    <string name="add_user">+ Add User</string>
+    <string name="blocked_users_description">Users who cannot see your mood and energy</string>
+    <string name="privacy_tips">Privacy Tips</string>
+    <string name="privacy_tip_change_anytime">• You can change these settings anytime</string>
+    <string name="privacy_tip_blocked_not_notified">• Blocked users won't be notified</string>
+    <string name="privacy_tip_close_friends_manage">• Close friends list can be managed in Friends settings</string>
 
 </resources>


### PR DESCRIPTION
## Summary
- Replace literal UI labels in dialogs and fragments with string resources
- Remove sample text placeholders and bind via tools attributes
- Centralize new labels in `strings.xml`

## Testing
- `./gradlew lint` *(fails: Build was configured to prefer settings repositories over project repositories but repository 'Google' was added by build file `build.gradle.kts`)*

------
https://chatgpt.com/codex/tasks/task_e_688e24093ad48324a587e3acb69d68e2