### PR TITLE
Remove sample blocked user layout

### DIFF
--- a/app/src/main/res/layout/fragment_privacy_settings.xml
+++ b/app/src/main/res/layout/fragment_privacy_settings.xml
@@ -468,61 +468,6 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="16dp" />
 
-        <!-- Sample blocked user for demonstration (hidden by default) -->
-        <LinearLayout
-            android:id="@+id/sampleBlockedUserLayout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:padding="12dp"
-            android:background="@drawable/battery_outline"
-            android:layout_marginBottom="16dp"
-            android:visibility="visible">
-
-            <ImageView
-                android:layout_width="40dp"
-                android:layout_height="40dp"
-                android:src="@drawable/ic_people"
-                android:background="@drawable/battery_outline"
-                android:backgroundTint="@android:color/darker_gray"
-                android:layout_marginEnd="12dp"
-                android:layout_gravity="center_vertical" />
-
-            <LinearLayout
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:orientation="vertical"
-                android:layout_gravity="center_vertical">
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:textSize="16sp"
-                    android:textStyle="bold"
-                    tools:text="John Smith" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:textSize="12sp"
-                    android:textColor="@android:color/darker_gray"
-                    tools:text="@johnsmith" />
-
-            </LinearLayout>
-
-            <ImageView
-                android:id="@+id/removeUserButton"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:src="@drawable/ic_delete"
-                android:tint="@color/red_500"
-                android:layout_gravity="center_vertical"
-                android:background="?android:attr/selectableItemBackgroundBorderless"
-                android:padding="4dp" />
-
-        </LinearLayout>
-
         <!-- Privacy Tips section -->
         <LinearLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
## Summary
- remove hardcoded sample blocked user layout from privacy settings screen so blocked users are shown only via RecyclerView

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e3908c5e083248dbb7bbf5fa9e8f4