### PR TITLE
Filter weekly stats by week start

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/features/home/ui/SimpleHomeFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/home/ui/SimpleHomeFragment.kt
@@ -100,7 +100,7 @@ class SimpleHomeFragment : Fragment() {
         lifecycleScope.launch {
             val weekStart = System.currentTimeMillis() - (7 * 24 * 60 * 60 * 1000)
             try {
-                val activityCount = database.activityDao().getActiveActivityCount()
+                val activityCount = database.activityDao().getActivitiesCountFromDate(weekStart)
                 tvWeeklyStats.text = getString(R.string.weekly_stats_message, activityCount)
             } catch (e: Exception) {
                 tvWeeklyStats.text = getString(R.string.weekly_stats_loading)


### PR DESCRIPTION
## Summary
- only count activities from the past week when updating weekly stats

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e422d9ae08324add011d07b7512f3