### PR TITLE
Enable survey navigation from profile

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/features/profile/ui/ProfileFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/profile/ui/ProfileFragment.kt
@@ -36,7 +36,6 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import com.example.socialbatterymanager.R
 import com.example.socialbatterymanager.data.model.User
-import com.example.socialbatterymanager.BuildConfig
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
@@ -158,11 +157,8 @@ class ProfileFragment : Fragment() {
             showRecalibrationDialog()
         }
 
-        // Hide survey feature in release builds until implemented
-        if (!BuildConfig.DEBUG) {
-            surveyButton.visibility = View.GONE
-        } else {
-            surveyButton.isEnabled = false
+        surveyButton.setOnClickListener {
+            findNavController().navigate(R.id.action_profileFragment_to_surveyFragment)
         }
 
         privacySettingsButton.setOnClickListener {

--- a/app/src/main/java/com/example/socialbatterymanager/features/survey/ui/SurveyFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/survey/ui/SurveyFragment.kt
@@ -1,0 +1,19 @@
+package com.example.socialbatterymanager.features.survey.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.example.socialbatterymanager.R
+
+class SurveyFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_survey, container, false)
+    }
+}
+

--- a/app/src/main/res/layout/fragment_survey.xml
+++ b/app/src/main/res/layout/fragment_survey.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/surveyTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/survey_title"
+        android:textAppearance="?attr/textAppearanceHeadlineSmall"
+        android:layout_marginBottom="16dp" />
+
+    <TextView
+        android:id="@+id/surveyMessage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/survey_message" />
+
+</LinearLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -58,12 +58,20 @@
         <action
             android:id="@+id/action_profileFragment_to_privacySettingsFragment"
             app:destination="@id/privacySettingsFragment" />
+        <action
+            android:id="@+id/action_profileFragment_to_surveyFragment"
+            app:destination="@id/surveyFragment" />
     </fragment>
 
     <fragment
         android:id="@+id/privacySettingsFragment"
         android:name="com.example.socialbatterymanager.features.privacy.ui.PrivacySettingsFragment"
         android:label="Privacy Settings" />
+
+    <fragment
+        android:id="@+id/surveyFragment"
+        android:name="com.example.socialbatterymanager.features.survey.ui.SurveyFragment"
+        android:label="@string/survey_title" />
 
     <fragment
         android:id="@+id/activitiesFragment"


### PR DESCRIPTION
## Summary
- add placeholder survey screen and layout
- wire survey button in profile to navigate to survey screen
- register survey navigation in nav graph

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e422f0168832493822494b0aad679