### PR TITLE
Enable automatic Android SDK download for tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,6 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false
+
+# Allow Gradle to download required Android SDK components so local.properties is not necessary
+android.experimental.sdkDownload=true


### PR DESCRIPTION
## Summary
- allow Gradle to fetch Android SDK components automatically so local.properties isn't required

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_688e3e5c74c08324ab3deae0fec5af30