### PR TITLE
Implement direct Activity deletion

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/data/database/ActivityDao.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/data/database/ActivityDao.kt
@@ -25,6 +25,9 @@ interface ActivityDao {
     
     @Query("UPDATE activities SET isDeleted = 1, updatedAt = :timestamp WHERE id = :id")
     suspend fun softDeleteActivity(id: Int, timestamp: Long = System.currentTimeMillis())
+
+    @Delete
+    suspend fun deleteActivity(activity: ActivityEntity)
     
     @Query("SELECT * FROM activities WHERE isDeleted = 0")
     suspend fun getAllActivitiesForBackup(): List<ActivityEntity>

--- a/app/src/main/java/com/example/socialbatterymanager/ui/activities/ActivitiesFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/ui/activities/ActivitiesFragment.kt
@@ -146,7 +146,8 @@ class ActivitiesFragment : Fragment() {
             .setPositiveButton(R.string.delete) { _, _ ->
                 lifecycleScope.launch {
                     try {
-                        database.activityDao().deleteActivity(activity.toEntity())
+                        val entity = activity.toEntity()
+                        database.activityDao().deleteActivity(entity)
                         Toast.makeText(
                             requireContext(),
                             getString(R.string.activity_delete_success),


### PR DESCRIPTION
## Summary
- add Room `@Delete` to remove activities directly
- wire ActivitiesFragment to call new DAO delete method

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e4ccb83588324854dd2d6e7a7886b