### PR TITLE
Implement social battery survey UI and submission logic

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/features/survey/ui/SurveyFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/survey/ui/SurveyFragment.kt
@@ -4,16 +4,53 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.RadioGroup
+import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
 import com.example.socialbatterymanager.R
 
 class SurveyFragment : Fragment() {
+
+    private lateinit var energyGroup: RadioGroup
+    private lateinit var socialGroup: RadioGroup
+    private lateinit var stressGroup: RadioGroup
+    private lateinit var submitButton: Button
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View? {
-        return inflater.inflate(R.layout.fragment_survey, container, false)
+        val view = inflater.inflate(R.layout.fragment_survey, container, false)
+
+        energyGroup = view.findViewById(R.id.energyGroup)
+        socialGroup = view.findViewById(R.id.socialGroup)
+        stressGroup = view.findViewById(R.id.stressGroup)
+        submitButton = view.findViewById(R.id.submitSurveyButton)
+
+        submitButton.setOnClickListener {
+            val energySelected = energyGroup.checkedRadioButtonId
+            val socialSelected = socialGroup.checkedRadioButtonId
+            val stressSelected = stressGroup.checkedRadioButtonId
+
+            if (energySelected == -1 || socialSelected == -1 || stressSelected == -1) {
+                Toast.makeText(
+                    requireContext(),
+                    getString(R.string.survey_incomplete),
+                    Toast.LENGTH_SHORT,
+                ).show()
+            } else {
+                Toast.makeText(
+                    requireContext(),
+                    getString(R.string.survey_submitted),
+                    Toast.LENGTH_SHORT,
+                ).show()
+                findNavController().navigateUp()
+            }
+        }
+
+        return view
     }
 }
-

--- a/app/src/main/res/layout/fragment_survey.xml
+++ b/app/src/main/res/layout/fragment_survey.xml
@@ -19,4 +19,104 @@
         android:layout_height="wrap_content"
         android:text="@string/survey_message" />
 
+    <TextView
+        android:id="@+id/energyQuestion"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="@string/survey_question_energy" />
+
+    <RadioGroup
+        android:id="@+id/energyGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+        <RadioButton
+            android:id="@+id/energyLow"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/survey_option_low" />
+
+        <RadioButton
+            android:id="@+id/energyMedium"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/survey_option_medium" />
+
+        <RadioButton
+            android:id="@+id/energyHigh"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/survey_option_high" />
+    </RadioGroup>
+
+    <TextView
+        android:id="@+id/socialQuestion"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="@string/survey_question_social" />
+
+    <RadioGroup
+        android:id="@+id/socialGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+        <RadioButton
+            android:id="@+id/socialLow"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/survey_option_low" />
+
+        <RadioButton
+            android:id="@+id/socialMedium"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/survey_option_medium" />
+
+        <RadioButton
+            android:id="@+id/socialHigh"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/survey_option_high" />
+    </RadioGroup>
+
+    <TextView
+        android:id="@+id/stressQuestion"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="@string/survey_question_stress" />
+
+    <RadioGroup
+        android:id="@+id/stressGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+        <RadioButton
+            android:id="@+id/stressLow"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/survey_option_low" />
+
+        <RadioButton
+            android:id="@+id/stressMedium"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/survey_option_medium" />
+
+        <RadioButton
+            android:id="@+id/stressHigh"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/survey_option_high" />
+    </RadioGroup>
+
+    <Button
+        android:id="@+id/submitSurveyButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        android:text="@string/survey_submit" />
+
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -250,6 +250,15 @@ Energy Ranges:
     <string name="survey_title">Social Battery Survey</string>
     <string name="survey_message">Take a quick survey to help us better understand your social energy patterns and improve your experience.</string>
     <string name="take_survey">Take Survey</string>
+    <string name="survey_question_energy">How much energy do you have right now?</string>
+    <string name="survey_question_social">How social do you feel today?</string>
+    <string name="survey_question_stress">How stressed do you feel?</string>
+    <string name="survey_option_low">Low</string>
+    <string name="survey_option_medium">Medium</string>
+    <string name="survey_option_high">High</string>
+    <string name="survey_submit">Submit</string>
+    <string name="survey_incomplete">Please answer all questions</string>
+    <string name="survey_submitted">Survey submitted. Thank you!</string>
     <string name="later">Later</string>
     <string name="sign_out_success">Signed out successfully</string>
     <string name="account_deleted_success">Account deleted successfully</string>


### PR DESCRIPTION
## Summary
- expand survey layout with energy, social and stress questions
- handle survey responses and submission navigation
- add string resources for survey questions and options

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./validate_navigation.sh`

------
https://chatgpt.com/codex/tasks/task_e_688e4ccc653483249582f43d45bd903e