### PR TITLE
Add ReportDataAnalyzer and LoginFragment tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,8 +114,10 @@ dependencies {
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation(platform("androidx.compose:compose-bom:2023.03.00"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    androidTestImplementation("androidx.fragment:fragment-testing:1.8.8")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
+    debugImplementation("androidx.fragment:fragment-testing:1.8.8")
 }
 
 // Ktlint configuration

--- a/app/src/androidTest/java/com/example/socialbatterymanager/HomeFunctionalityTest.kt
+++ b/app/src/androidTest/java/com/example/socialbatterymanager/HomeFunctionalityTest.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.example.socialbatterymanager.data.ActivityEntity
-import com.example.socialbatterymanager.data.AppDatabase
+import com.example.socialbatterymanager.data.database.AppDatabase
+import com.example.socialbatterymanager.data.model.ActivityEntity
 import com.example.socialbatterymanager.data.model.EnergyLog
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking

--- a/app/src/androidTest/java/com/example/socialbatterymanager/calendar/CalendarIntegrationTest.kt
+++ b/app/src/androidTest/java/com/example/socialbatterymanager/calendar/CalendarIntegrationTest.kt
@@ -2,7 +2,7 @@ package com.example.socialbatterymanager.calendar
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import com.example.socialbatterymanager.data.AppDatabase
+import com.example.socialbatterymanager.data.database.AppDatabase
 import com.example.socialbatterymanager.data.model.CalendarEvent
 import kotlinx.coroutines.runBlocking
 import org.junit.After

--- a/app/src/androidTest/java/com/example/socialbatterymanager/features/auth/LoginFragmentTest.kt
+++ b/app/src/androidTest/java/com/example/socialbatterymanager/features/auth/LoginFragmentTest.kt
@@ -1,0 +1,24 @@
+package com.example.socialbatterymanager.features.auth
+
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.socialbatterymanager.R
+import com.example.socialbatterymanager.features.auth.ui.LoginFragment
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LoginFragmentTest {
+    @Test
+    fun signInUiIsDisplayed() {
+        launchFragmentInContainer<LoginFragment>(themeResId = R.style.Theme_SocialBatteryManager)
+
+        onView(withId(R.id.emailEditText)).check(matches(isDisplayed()))
+        onView(withId(R.id.passwordEditText)).check(matches(isDisplayed()))
+        onView(withId(R.id.signInButton)).check(matches(isDisplayed()))
+    }
+}

--- a/app/src/test/java/com/example/socialbatterymanager/reports/ReportDataAnalyzerTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/reports/ReportDataAnalyzerTest.kt
@@ -1,0 +1,78 @@
+package com.example.socialbatterymanager.reports
+
+import com.example.socialbatterymanager.data.model.ActivityEntity
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.Calendar
+import java.util.Locale
+
+class ReportDataAnalyzerTest {
+
+    @Test
+    fun aggregateEnergyData_groupsByDay() {
+        Locale.setDefault(Locale.US)
+        val cal = Calendar.getInstance()
+        cal.set(2023, Calendar.JANUARY, 2, 10, 0, 0)
+        cal.set(Calendar.MILLISECOND, 0)
+        val monday = cal.timeInMillis
+        cal.set(2023, Calendar.JANUARY, 3, 10, 0, 0)
+        cal.set(Calendar.MILLISECOND, 0)
+        val tuesday = cal.timeInMillis
+
+        val activities = listOf(
+            ActivityEntity(name = "A", type = "work", energy = 4, people = "", mood = "", notes = "", date = monday),
+            ActivityEntity(name = "B", type = "work", energy = 6, people = "", mood = "", notes = "", date = tuesday)
+        )
+
+        val result = ReportDataAnalyzer.aggregateEnergyData(activities, ReportPeriod.WEEK)
+
+        assertEquals(listOf("Mon", "Tue"), result.map { it.label })
+        assertEquals(listOf(4f, 6f), result.map { it.value })
+    }
+
+    private fun activityAt(hour: Int, energy: Int): ActivityEntity {
+        val cal = Calendar.getInstance()
+        cal.set(2023, Calendar.JANUARY, 1, hour, 0, 0)
+        cal.set(Calendar.MILLISECOND, 0)
+        return ActivityEntity(
+            name = "A",
+            type = "work",
+            energy = energy,
+            people = "",
+            mood = "",
+            notes = "",
+            date = cal.timeInMillis
+        )
+    }
+
+    @Test
+    fun analyzePeakUsageTimes_classifiesUsageLevels() {
+        val activities = mutableListOf<ActivityEntity>().apply {
+            repeat(3) { add(activityAt(9, 2)) }
+            repeat(2) { add(activityAt(14, 8)) }
+            add(activityAt(18, 4))
+        }
+
+        val peakTimes = ReportDataAnalyzer.analyzePeakUsageTimes(activities)
+
+        assertEquals("9:00 - 10:00", peakTimes[0].timeRange)
+        assertEquals(UsageLevel.HIGH_DRAIN, peakTimes[0].level)
+        assertEquals(50f, peakTimes[0].percentage, 0.1f)
+        assertEquals(UsageLevel.RECHARGE, peakTimes[1].level)
+        assertEquals(UsageLevel.MEDIUM_DRAIN, peakTimes[2].level)
+    }
+
+    @Test
+    fun generateAIInsights_returnsAllTypes() {
+        val insights = ReportDataAnalyzer.generateAIInsights(emptyList())
+        assertEquals(4, insights.size)
+        val types = insights.map { it.type }.toSet()
+        val expected = setOf(
+            InsightType.DO_MORE,
+            InsightType.REDUCE,
+            InsightType.PATTERN_DETECTED,
+            InsightType.OPTIMIZE_CONTACTS
+        )
+        assertEquals(expected, types)
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for ReportDataAnalyzer covering aggregation, peak usage analysis, and AI insight generation
- add LoginFragmentTest using FragmentScenario to verify sign-in UI
- include fragment-testing dependency and fix instrumented test imports

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew connectedAndroidTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e4cd04bc08324b5ab2befbd75d9c1