### PR TITLE
Add Android CI workflow with emulator tests

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -7,30 +7,23 @@ on:
     branches: [ main ]
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
 
     steps:
-      # 1️⃣ Checkout the code
-      - name: Checkout code
+      - name: Checkout repository
         uses: actions/checkout@v4
 
-      # 2️⃣ Set up JDK for Gradle/Android
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: temurin
+          java-version: 17
+          cache: gradle
 
-      # 3️⃣ Install Android SDK & required packages
-      - name: Install Android SDK
+      - name: Set up Android SDK
         uses: android-actions/setup-android@v3
 
-      # ✅ Extra: Ensure all required SDK tools & system images are installed
-      - name: Install Emulator Packages
-        run: sdkmanager --install "system-images;android-30;default;x86_64" "platforms;android-30" "platform-tools" "emulator"
-
-      # 4️⃣ Cache Gradle to speed up builds
       - name: Cache Gradle
         uses: actions/cache@v4
         with:
@@ -38,39 +31,62 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          restore-keys: ${{ runner.os }}-gradle-
 
-      # 5️⃣ Run JVM Unit Tests (fast, no emulator needed)
-      - name: Run Unit Tests
+      - name: Install SDK components
+        run: sdkmanager --install "platform-tools" "platforms;android-30" "build-tools;30.0.3"
+
+      - name: Run JVM unit tests
         run: ./gradlew test
+
+      - name: Assemble debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Upload APK artifact
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug
+          path: app/build/outputs/apk/debug/app-debug.apk
 
   instrumented-tests:
     runs-on: ubuntu-latest
-    needs: test
+    needs: build
+    strategy:
+      matrix:
+        api-level: [30, 34]
 
     steps:
-      - name: Checkout code
+      - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: temurin
+          java-version: 17
+          cache: gradle
 
-      - name: Install Android SDK
+      - name: Set up Android SDK
         uses: android-actions/setup-android@v3
 
-      - name: Install Emulator Packages
-        run: sdkmanager --install "system-images;android-30;default;x86_64" "platforms;android-30" "platform-tools" "emulator"
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
 
-      # ✅ Set up Android Emulator
-      - name: Start Emulator
+      - name: Install emulator packages
+        run: sdkmanager --install "platform-tools" "platforms;android-${{ matrix.api-level }}" "system-images;android-${{ matrix.api-level }};google_apis;x86_64" "emulator"
+
+      - name: Run instrumented tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 30
-          target: default
+          api-level: ${{ matrix.api-level }}
+          target: google_apis
           arch: x86_64
           profile: pixel_5
           script: ./gradlew connectedCheck


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for building, unit tests, and emulator-backed instrumented tests
- enable Gradle caching and Android SDK setup with JDK 17
- upload debug APK artifact after successful build

## Testing
- `yamllint .github/workflows/android-ci.yml` *(command not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68905ca7b44c8324ba0ad84a364581c6