### PR TITLE
Disable Android backups and secure data extraction

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,7 +30,7 @@
 
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
-    <include domain="sharedpref" path="profile_prefs.xml"/>
-    <exclude domain="sharedpref" path="encrypted_prefs.xml"/>
-    <include domain="database" path="social_battery_db"/>
-    <exclude domain="database" path="*-journal"/>
-    <include domain="file" path="."/>
-    <exclude domain="file" path="cache/"/>
+    <!-- Explicitly exclude all app data to prevent accidental backups -->
+    <exclude domain="sharedpref" path="."/>
+    <exclude domain="database" path="."/>
+    <exclude domain="file" path="."/>
 </full-backup-content>
-

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,20 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <data-extraction-rules>
     <cloud-backup>
-        <include domain="sharedpref" path="profile_prefs.xml"/>
-        <exclude domain="sharedpref" path="encrypted_prefs.xml"/>
-        <include domain="database" path="social_battery_db"/>
-        <exclude domain="database" path="*-journal"/>
-        <include domain="file" path="."/>
-        <exclude domain="file" path="cache/"/>
+        <!-- Exclude all data from cloud backups -->
+        <exclude domain="sharedpref" path="."/>
+        <exclude domain="database" path="."/>
+        <exclude domain="file" path="."/>
     </cloud-backup>
     <device-transfer>
-        <include domain="sharedpref" path="profile_prefs.xml"/>
-        <exclude domain="sharedpref" path="encrypted_prefs.xml"/>
-        <include domain="database" path="social_battery_db"/>
-        <exclude domain="database" path="*-journal"/>
-        <include domain="file" path="."/>
-        <exclude domain="file" path="cache/"/>
+        <!-- Exclude all data from device-to-device transfers -->
+        <exclude domain="sharedpref" path="."/>
+        <exclude domain="database" path="."/>
+        <exclude domain="file" path="."/>
     </device-transfer>
 </data-extraction-rules>
-


### PR DESCRIPTION
## Summary
- turn off `android:allowBackup` to prevent unintended ADB or system restores
- tighten backup and data extraction rules to exclude all app data

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68906a0aaeb883249ee8cc21a171a5fd