### PR TITLE
Add HomeRepository and inject into SimpleHomeViewModel

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/features/home/data/HomeRepository.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/home/data/HomeRepository.kt
@@ -1,0 +1,9 @@
+package com.example.socialbatterymanager.features.home.data
+
+import com.example.socialbatterymanager.data.database.AppDatabase
+
+class HomeRepository(private val database: AppDatabase) {
+    suspend fun getActivitiesCountFromDate(fromDate: Long): Int {
+        return database.activityDao().getActivitiesCountFromDate(fromDate)
+    }
+}

--- a/app/src/main/java/com/example/socialbatterymanager/features/home/ui/SimpleHomeFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/home/ui/SimpleHomeFragment.kt
@@ -16,6 +16,7 @@ import androidx.navigation.fragment.findNavController
 import com.example.socialbatterymanager.BuildConfig
 import com.example.socialbatterymanager.R
 import com.example.socialbatterymanager.data.database.AppDatabase
+import com.example.socialbatterymanager.features.home.data.HomeRepository
 import com.example.socialbatterymanager.features.notifications.NotificationService
 import kotlinx.coroutines.launch
 
@@ -32,7 +33,8 @@ class SimpleHomeFragment : Fragment() {
         object : ViewModelProvider.Factory {
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
                 val db = AppDatabase.getDatabase(requireContext())
-                return SimpleHomeViewModel(db) as T
+                val repository = HomeRepository(db)
+                return SimpleHomeViewModel(repository) as T
             }
         }
     }

--- a/app/src/main/java/com/example/socialbatterymanager/features/home/ui/SimpleHomeViewModel.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/home/ui/SimpleHomeViewModel.kt
@@ -4,10 +4,10 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.socialbatterymanager.data.database.AppDatabase
+import com.example.socialbatterymanager.features.home.data.HomeRepository
 import kotlinx.coroutines.launch
 
-class SimpleHomeViewModel(private val database: AppDatabase) : ViewModel() {
+class SimpleHomeViewModel(private val homeRepository: HomeRepository) : ViewModel() {
 
     private val _weeklyActivityCount = MutableLiveData<Int>()
     val weeklyActivityCount: LiveData<Int> = _weeklyActivityCount
@@ -15,7 +15,7 @@ class SimpleHomeViewModel(private val database: AppDatabase) : ViewModel() {
     fun loadWeeklyStats() {
         viewModelScope.launch {
             val weekStart = System.currentTimeMillis() - (7 * 24 * 60 * 60 * 1000)
-            val count = database.activityDao().getActivitiesCountFromDate(weekStart)
+            val count = homeRepository.getActivitiesCountFromDate(weekStart)
             _weeklyActivityCount.value = count
         }
     }

--- a/app/src/test/java/com/example/socialbatterymanager/features/home/HomeRepositoryTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/features/home/HomeRepositoryTest.kt
@@ -1,0 +1,59 @@
+package com.example.socialbatterymanager.features.home
+
+import com.example.socialbatterymanager.features.home.data.HomeRepository
+import com.example.socialbatterymanager.data.database.*
+import com.example.socialbatterymanager.data.model.ActivityEntity
+import com.example.socialbatterymanager.data.model.SyncStatus
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+private class FakeActivityDao(private val count: Int) : ActivityDao {
+    var receivedFromDate: Long? = null
+    override suspend fun getActivitiesCountFromDate(fromDate: Long): Int {
+        receivedFromDate = fromDate
+        return count
+    }
+    override suspend fun insertActivity(activity: ActivityEntity): Long = throw NotImplementedError()
+    override suspend fun updateActivity(activity: ActivityEntity) = throw NotImplementedError()
+    override fun getAllActivities(): Flow<List<ActivityEntity>> = throw NotImplementedError()
+    override suspend fun getActivityById(id: Int): ActivityEntity? = throw NotImplementedError()
+    override suspend fun softDeleteActivity(id: Int, timestamp: Long) = throw NotImplementedError()
+    override suspend fun deleteActivity(activity: ActivityEntity) = throw NotImplementedError()
+    override suspend fun getAllActivitiesForBackup(): List<ActivityEntity> = throw NotImplementedError()
+    override suspend fun getActiveActivityCount(): Int = throw NotImplementedError()
+    override suspend fun hardDeleteOldActivities(cutoff: Long) = throw NotImplementedError()
+    override suspend fun getActivitiesBySyncStatus(status: SyncStatus): List<ActivityEntity> = throw NotImplementedError()
+    override suspend fun updateSyncStatus(id: Int, status: SyncStatus) = throw NotImplementedError()
+    override suspend fun updateFirebaseId(id: Int, firebaseId: String) = throw NotImplementedError()
+    override suspend fun incrementUsageCount(id: Int) = throw NotImplementedError()
+    override suspend fun getActivitiesByDateRangeSync(start: Long, end: Long): List<ActivityEntity> = throw NotImplementedError()
+    override suspend fun getTotalEnergyUsedFromDate(fromDate: Long): Int = throw NotImplementedError()
+}
+
+private class FakeAppDatabase(private val activityDao: ActivityDao) : AppDatabase() {
+    override fun activityDao(): ActivityDao = activityDao
+    override fun auditLogDao(): AuditLogDao = throw NotImplementedError()
+    override fun backupMetadataDao(): BackupMetadataDao = throw NotImplementedError()
+    override fun energyLogDao(): EnergyLogDao = throw NotImplementedError()
+    override fun userDao(): UserDao = throw NotImplementedError()
+    override fun personDao(): PersonDao = throw NotImplementedError()
+    override fun calendarEventDao(): CalendarEventDao = throw NotImplementedError()
+    override fun notificationDao(): NotificationDao = throw NotImplementedError()
+}
+
+class HomeRepositoryTest {
+    @Test
+    fun getActivitiesCountFromDate_delegatesToDao() = runBlocking {
+        val expectedCount = 5
+        val fakeDao = FakeActivityDao(expectedCount)
+        val repository = HomeRepository(FakeAppDatabase(fakeDao))
+        val fromDate = 100L
+
+        val result = repository.getActivitiesCountFromDate(fromDate)
+
+        assertEquals(expectedCount, result)
+        assertEquals(fromDate, fakeDao.receivedFromDate)
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `HomeRepository` to abstract activity count queries
- inject `HomeRepository` into `SimpleHomeViewModel` and update fragment to provide it
- add unit test verifying repository delegation to DAO

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `sudo apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68906a0a0c8c8324bc5fdebe03f135ff