### PR TITLE
Add DataRepository and SyncWorker tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -128,6 +128,7 @@ dependencies {
     androidTestImplementation(platform("androidx.compose:compose-bom:2024.09.00"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     androidTestImplementation("androidx.fragment:fragment-testing:1.8.8")
+    androidTestImplementation("androidx.work:work-testing:2.9.0")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
     debugImplementation("androidx.fragment:fragment-testing:1.8.8")

--- a/app/src/androidTest/java/com/example/socialbatterymanager/sync/SyncWorkerTest.kt
+++ b/app/src/androidTest/java/com/example/socialbatterymanager/sync/SyncWorkerTest.kt
@@ -1,0 +1,86 @@
+package com.example.socialbatterymanager.sync
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.Configuration
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.WorkerFactory
+import androidx.work.WorkerParameters
+import androidx.work.testing.SynchronousExecutor
+import androidx.work.testing.WorkManagerTestInitHelper
+import com.example.socialbatterymanager.data.database.AppDatabase
+import com.example.socialbatterymanager.shared.utils.NetworkStatusProvider
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.firestore.FirebaseFirestore
+import java.util.concurrent.TimeUnit
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private class FakeNetworkManager(var connected: Boolean) : NetworkStatusProvider {
+    var unregistered = false
+    override fun isCurrentlyConnected(): Boolean = connected
+    override fun unregister() { unregistered = true }
+}
+
+@RunWith(AndroidJUnit4::class)
+class SyncWorkerTest {
+    private lateinit var context: Context
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        FirebaseApp.initializeApp(
+            context,
+            FirebaseOptions.Builder()
+                .setProjectId("test")
+                .setApplicationId("1:1:test")
+                .setApiKey("test")
+                .build()
+        )
+    }
+
+    @After
+    fun tearDown() {
+        FirebaseApp.clearInstancesForTest()
+        AppDatabase.clearInstance()
+    }
+
+    @Test
+    fun workerRetriesWhenOffline() {
+        val network = FakeNetworkManager(false)
+        val db = AppDatabase.getDatabase(context)
+        val firestore = FirebaseFirestore.getInstance()
+
+        val factory = object : WorkerFactory() {
+            override fun createWorker(appContext: Context, workerClassName: String, workerParameters: WorkerParameters): androidx.work.ListenableWorker? {
+                return if (workerClassName == SyncWorker::class.java.name) {
+                    SyncWorker(appContext, workerParameters, db, firestore, network)
+                } else {
+                    null
+                }
+            }
+        }
+
+        val config = Configuration.Builder()
+            .setExecutor(SynchronousExecutor())
+            .setWorkerFactory(factory)
+            .build()
+        WorkManagerTestInitHelper.initializeTestWorkManager(context, config)
+
+        val request = OneTimeWorkRequestBuilder<SyncWorker>().build()
+        val workManager = WorkManager.getInstance(context)
+        workManager.enqueue(request).result.get(10, TimeUnit.SECONDS)
+        val info = workManager.getWorkInfoById(request.id).get()
+
+        assertEquals(WorkInfo.State.RETRY, info.state)
+        assertTrue(network.unregistered)
+    }
+}

--- a/app/src/main/java/com/example/socialbatterymanager/shared/utils/NetworkConnectivityManager.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/shared/utils/NetworkConnectivityManager.kt
@@ -11,9 +11,17 @@ import kotlinx.coroutines.flow.asStateFlow
 import com.example.socialbatterymanager.R
 
 /**
+ * Minimal interface used for testing network connectivity
+ */
+interface NetworkStatusProvider {
+    fun isCurrentlyConnected(): Boolean
+    fun unregister()
+}
+
+/**
  * Utility class for monitoring network connectivity
  */
-class NetworkConnectivityManager(private val context: Context) {
+class NetworkConnectivityManager(private val context: Context) : NetworkStatusProvider {
     
     private val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
     
@@ -56,7 +64,7 @@ class NetworkConnectivityManager(private val context: Context) {
     /**
      * Check if device is currently connected to the internet
      */
-    fun isCurrentlyConnected(): Boolean {
+    override fun isCurrentlyConnected(): Boolean {
         val network = connectivityManager.activeNetwork
         val networkCapabilities = connectivityManager.getNetworkCapabilities(network)
         return networkCapabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
@@ -107,7 +115,7 @@ class NetworkConnectivityManager(private val context: Context) {
     /**
      * Unregister network callback to prevent memory leaks
      */
-    fun unregister() {
+    override fun unregister() {
         connectivityManager.unregisterNetworkCallback(networkCallback)
     }
 }

--- a/app/src/main/java/com/example/socialbatterymanager/sync/SyncWorker.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/sync/SyncWorker.kt
@@ -8,6 +8,7 @@ import com.example.socialbatterymanager.data.database.AppDatabase
 import com.example.socialbatterymanager.data.model.ActivityEntity
 import com.example.socialbatterymanager.data.model.SyncStatus
 import com.example.socialbatterymanager.shared.utils.NetworkConnectivityManager
+import com.example.socialbatterymanager.shared.utils.NetworkStatusProvider
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
@@ -17,12 +18,11 @@ import kotlinx.coroutines.tasks.await
  */
 class SyncWorker(
     context: Context,
-    workerParams: WorkerParameters
+    workerParams: WorkerParameters,
+    private val database: AppDatabase = AppDatabase.getDatabase(context),
+    private val firestore: FirebaseFirestore = FirebaseFirestore.getInstance(),
+    private val networkManager: NetworkStatusProvider = NetworkConnectivityManager(context),
 ) : CoroutineWorker(context, workerParams) {
-    
-    private val database = AppDatabase.getDatabase(applicationContext)
-    private val firestore = FirebaseFirestore.getInstance()
-    private val networkManager = NetworkConnectivityManager(applicationContext)
     
     override suspend fun doWork(): Result {
         return try {

--- a/app/src/test/java/com/example/socialbatterymanager/data/repository/DataRepositoryAuditBackupTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/data/repository/DataRepositoryAuditBackupTest.kt
@@ -1,0 +1,123 @@
+package com.example.socialbatterymanager.data.repository
+
+import com.example.socialbatterymanager.data.database.*
+import com.example.socialbatterymanager.data.model.ActivityEntity
+import com.example.socialbatterymanager.data.model.AuditLogEntity
+import com.example.socialbatterymanager.data.model.BackupMetadataEntity
+import com.example.socialbatterymanager.data.model.SyncStatus
+import com.google.gson.Gson
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+private class FakeActivityDao : ActivityDao {
+    val activities = mutableListOf<ActivityEntity>()
+    override suspend fun insertActivity(activity: ActivityEntity): Long {
+        activities += activity
+        return activity.id.toLong()
+    }
+    override suspend fun updateActivity(activity: ActivityEntity) {
+        val index = activities.indexOfFirst { it.id == activity.id }
+        if (index >= 0) activities[index] = activity
+    }
+    override fun getAllActivities(): Flow<List<ActivityEntity>> = MutableStateFlow(activities.toList())
+    override suspend fun getActivityById(id: Int): ActivityEntity? = activities.find { it.id == id }
+    override suspend fun softDeleteActivity(id: Int, timestamp: Long) {
+        val index = activities.indexOfFirst { it.id == id }
+        if (index >= 0) {
+            val old = activities[index]
+            activities[index] = old.copy(isDeleted = 1, updatedAt = timestamp)
+        }
+    }
+    override suspend fun deleteActivity(activity: ActivityEntity) { activities.removeIf { it.id == activity.id } }
+    override suspend fun getAllActivitiesForBackup(): List<ActivityEntity> = activities.filter { it.isDeleted == 0 }
+    override suspend fun getActiveActivityCount(): Int = activities.count { it.isDeleted == 0 }
+    override suspend fun hardDeleteOldActivities(cutoff: Long) {}
+    override suspend fun getActivitiesBySyncStatus(status: SyncStatus): List<ActivityEntity> = activities.filter { it.syncStatus == status }
+    override suspend fun updateSyncStatus(id: Int, status: SyncStatus) {}
+    override suspend fun updateFirebaseId(id: Int, firebaseId: String) {}
+    override suspend fun incrementUsageCount(id: Int) {}
+    override suspend fun getActivitiesByDateRangeSync(start: Long, end: Long): List<ActivityEntity> = emptyList()
+    override suspend fun getActivitiesCountFromDate(fromDate: Long): Int = 0
+    override suspend fun getTotalEnergyUsedFromDate(fromDate: Long): Int = 0
+}
+
+private class FakeAuditLogDao : AuditLogDao {
+    val logs = MutableStateFlow<List<AuditLogEntity>>(emptyList())
+    override suspend fun insertAuditLog(auditLog: AuditLogEntity) {
+        logs.value = logs.value + auditLog
+    }
+    override fun getAllAuditLogs(): Flow<List<AuditLogEntity>> = logs
+    override fun getAuditLogsForEntity(entityType: String, entityId: String): Flow<List<AuditLogEntity>> =
+        MutableStateFlow(logs.value.filter { it.entityType == entityType && it.entityId == entityId })
+    override fun getAuditLogsSince(since: Long): Flow<List<AuditLogEntity>> =
+        MutableStateFlow(logs.value.filter { it.timestamp > since })
+    override suspend fun deleteAuditLogsOlderThan(cutoff: Long) {
+        logs.value = logs.value.filter { it.timestamp >= cutoff }
+    }
+    override suspend fun getAuditLogCount(): Int = logs.value.size
+}
+
+private class FakeBackupMetadataDao : BackupMetadataDao {
+    val metadata = mutableListOf<BackupMetadataEntity>()
+    override suspend fun insertBackupMetadata(metadata: BackupMetadataEntity) { this.metadata += metadata }
+    override suspend fun updateBackupMetadata(metadata: BackupMetadataEntity) {}
+    override fun getAllBackupMetadata(): Flow<List<BackupMetadataEntity>> = MutableStateFlow(metadata.toList())
+    override suspend fun getBackupMetadataById(id: String): BackupMetadataEntity? = metadata.find { it.id == id }
+    override suspend fun getLatestBackupMetadata(): BackupMetadataEntity? = metadata.maxByOrNull { it.timestamp }
+    override suspend fun deleteBackupMetadata(id: String) { metadata.removeIf { it.id == id } }
+}
+
+private class FakeAppDatabase : AppDatabase() {
+    val activityDao = FakeActivityDao()
+    val auditLogDao = FakeAuditLogDao()
+    val backupDao = FakeBackupMetadataDao()
+    override fun activityDao(): ActivityDao = activityDao
+    override fun auditLogDao(): AuditLogDao = auditLogDao
+    override fun backupMetadataDao(): BackupMetadataDao = backupDao
+    override fun energyLogDao(): EnergyLogDao = throw NotImplementedError()
+    override fun userDao(): UserDao = throw NotImplementedError()
+    override fun personDao(): PersonDao = throw NotImplementedError()
+    override fun calendarEventDao(): CalendarEventDao = throw NotImplementedError()
+    override fun notificationDao(): NotificationDao = throw NotImplementedError()
+}
+
+class DataRepositoryAuditBackupTest {
+    private fun createRepository(db: FakeAppDatabase): DataRepository {
+        val constructor = DataRepository::class.java.getDeclaredConstructor(AppDatabase::class.java, Gson::class.java)
+        constructor.isAccessible = true
+        return constructor.newInstance(db, Gson())
+    }
+
+    @Test
+    fun insertAndDeleteActivity_logsAuditEntries() = runBlocking {
+        val db = FakeAppDatabase()
+        val repo = createRepository(db)
+        val activity = ActivityEntity(id = 1, name = "A", type = "T", energy = 1, people = "P", mood = "M", notes = "N", date = 0)
+
+        repo.insertActivity(activity, userId = "u1")
+        repo.deleteActivity(activity.id, userId = "u2")
+
+        val logs = db.auditLogDao.logs.value
+        assertEquals(2, logs.size)
+        assertEquals("create", logs[0].action)
+        assertEquals("delete", logs[1].action)
+    }
+
+    @Test
+    fun createBackup_storesMetadata() = runBlocking {
+        val db = FakeAppDatabase()
+        val repo = createRepository(db)
+        val activity = ActivityEntity(id = 1, name = "A", type = "T", energy = 1, people = "P", mood = "M", notes = "N", date = 0)
+        repo.insertActivity(activity)
+
+        val metadata = repo.createBackup()
+        assertNotNull(metadata)
+        assertEquals(1, metadata.dataCount)
+        assertEquals(1, db.backupDao.metadata.size)
+        assertEquals(metadata.id, db.backupDao.metadata.first().id)
+    }
+}


### PR DESCRIPTION
## Summary
- add interface and dependency injection for SyncWorker network checks
- add DataRepository audit log and backup unit tests
- add WorkManager-based integration test for SyncWorker

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew connectedAndroidTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68906a0b765c83249fab7431b02c2d28