### PR TITLE
ci: add api 35 emulator

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -34,7 +34,7 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle-
 
       - name: Install SDK components
-        run: sdkmanager --install "platform-tools" "platforms;android-30" "build-tools;30.0.3"
+        run: sdkmanager --install "platform-tools" "platforms;android-30" "build-tools;30.0.3" "platforms;android-35" "build-tools;35.0.0"
 
       - name: Run JVM unit tests
         run: ./gradlew test
@@ -54,7 +54,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        api-level: [30, 34]
+        api-level: [30, 34, 35]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -29,6 +29,9 @@ jobs:
   connected-tests:
     runs-on: ubuntu-latest
     needs: build
+    strategy:
+      matrix:
+        api-level: [30, 34, 35]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -43,10 +46,13 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
 
+      - name: Install emulator packages
+        run: sdkmanager --install "platform-tools" "platforms;android-${{ matrix.api-level }}" "system-images;android-${{ matrix.api-level }};google_apis;x86_64" "emulator"
+
       - name: Run connectedAndroidTest on emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 34
+          api-level: ${{ matrix.api-level }}
           target: google_apis
           arch: x86_64
           profile: pixel_5


### PR DESCRIPTION
## Summary
- include API level 35 in Android workflow matrices
- install Android 35 platform and build-tools in CI

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68907fb4287c83248e9632b95410971d