### PR TITLE
refactor: limit proguard keep rules

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -29,3 +29,25 @@
 
 # Keep Worker implementations for WorkManager
 -keep class com.example.socialbatterymanager.sync.** { *; }
+
+# Keep only the PDFBox classes referenced in the app
+-keep class org.apache.pdfbox.pdmodel.PDDocument { *; }
+-keep class org.apache.pdfbox.pdmodel.PDPage { *; }
+-keep class org.apache.pdfbox.pdmodel.common.PDRectangle { *; }
+-keep class org.apache.pdfbox.pdmodel.PDPageContentStream { *; }
+-keep class org.apache.pdfbox.pdmodel.font.PDType1Font { *; }
+
+# Keep only the MPAndroidChart classes referenced in the app
+-keep class com.github.mikephil.charting.charts.LineChart { *; }
+-keep class com.github.mikephil.charting.charts.BarChart { *; }
+-keep class com.github.mikephil.charting.data.Entry { *; }
+-keep class com.github.mikephil.charting.data.LineData { *; }
+-keep class com.github.mikephil.charting.data.LineDataSet { *; }
+-keep class com.github.mikephil.charting.data.BarEntry { *; }
+-keep class com.github.mikephil.charting.data.BarData { *; }
+-keep class com.github.mikephil.charting.data.BarDataSet { *; }
+-keep class com.github.mikephil.charting.formatter.IndexAxisValueFormatter { *; }
+
+# Suppress warnings from unused classes in these libraries
+-dontwarn org.apache.pdfbox.**
+-dontwarn com.github.mikephil.charting.**


### PR DESCRIPTION
## Summary
- limit ProGuard keeps to the PDFBox and MPAndroidChart classes actually used
- suppress warnings from unused classes in those libraries to cut log noise

## Testing
- `./gradlew assembleRelease` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68907fb588e4832492c8bed92f8df312