### PR TITLE
Add tests for home view model and fragment

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -128,6 +128,11 @@ dependencies {
 
     // Test dependencies
     testImplementation("junit:junit:4.13.2")
+    testImplementation("androidx.arch.core:core-testing:2.2.0")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
+    testImplementation("io.mockk:mockk:1.13.11")
+    testImplementation("org.robolectric:robolectric:4.12.1")
+
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation(platform("androidx.compose:compose-bom:2024.09.00"))

--- a/app/src/test/java/com/example/socialbatterymanager/features/home/SimpleHomeFragmentTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/features/home/SimpleHomeFragmentTest.kt
@@ -1,0 +1,55 @@
+package com.example.socialbatterymanager.features.home
+
+import android.widget.Button
+import android.widget.TextView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.socialbatterymanager.R
+import com.example.socialbatterymanager.features.home.ui.SimpleHomeFragment
+import com.example.socialbatterymanager.features.notifications.NotificationService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+
+@RunWith(AndroidJUnit4::class)
+class SimpleHomeFragmentTest {
+
+    @Test
+    fun clickingAddEnergy_updatesLevelAndNotifies() {
+        val controller = Robolectric.buildFragment(SimpleHomeFragment::class.java).create().start().resume()
+        val fragment = controller.get()
+        val mockService = mockk<NotificationService>(relaxed = true, constructorArgs = arrayOf(fragment.requireContext()))
+        val field = SimpleHomeFragment::class.java.getDeclaredField("notificationService")
+        field.isAccessible = true
+        field.set(fragment, mockService)
+
+        val btnAdd = fragment.requireView().findViewById<Button>(R.id.btnAddEnergy)
+        val tvEnergy = fragment.requireView().findViewById<TextView>(R.id.tvEnergyLevel)
+
+        btnAdd.performClick()
+
+        assertEquals("70%", tvEnergy.text.toString())
+        verify { mockService.checkAndGenerateEnergyLowNotification(70) }
+    }
+
+    @Test
+    fun clickingRemoveEnergy_updatesLevelAndNotifies() {
+        val controller = Robolectric.buildFragment(SimpleHomeFragment::class.java).create().start().resume()
+        val fragment = controller.get()
+        val mockService = mockk<NotificationService>(relaxed = true, constructorArgs = arrayOf(fragment.requireContext()))
+        val field = SimpleHomeFragment::class.java.getDeclaredField("notificationService")
+        field.isAccessible = true
+        field.set(fragment, mockService)
+
+        val btnRemove = fragment.requireView().findViewById<Button>(R.id.btnRemoveEnergy)
+        val tvEnergy = fragment.requireView().findViewById<TextView>(R.id.tvEnergyLevel)
+
+        btnRemove.performClick()
+
+        assertEquals("60%", tvEnergy.text.toString())
+        verify { mockService.checkAndGenerateEnergyLowNotification(60) }
+    }
+}

--- a/app/src/test/java/com/example/socialbatterymanager/features/home/SimpleHomeViewModelTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/features/home/SimpleHomeViewModelTest.kt
@@ -1,0 +1,58 @@
+package com.example.socialbatterymanager.features.home
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.example.socialbatterymanager.data.database.ActivityDao
+import com.example.socialbatterymanager.data.database.AppDatabase
+import com.example.socialbatterymanager.features.home.data.HomeRepository
+import com.example.socialbatterymanager.features.home.ui.SimpleHomeViewModel
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SimpleHomeViewModelTest {
+
+    @get:Rule
+    val instantRule = InstantTaskExecutorRule()
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun loadWeeklyStats_postsActivityCount() = runTest {
+        val expected = 4
+        val activityDao = mockk<ActivityDao>()
+        coEvery { activityDao.getActivitiesCountFromDate(any()) } returns expected
+        val database = mockk<AppDatabase>()
+        every { database.activityDao() } returns activityDao
+
+        val repository = HomeRepository(database)
+        val viewModel = SimpleHomeViewModel(repository)
+
+        viewModel.loadWeeklyStats()
+        advanceUntilIdle()
+
+        assertEquals(expected, viewModel.weeklyActivityCount.value)
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for `SimpleHomeViewModel.loadWeeklyStats`
- add Robolectric tests for `SimpleHomeFragment` click handlers
- configure test dependencies (MockK, Robolectric, coroutine testing)

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68907fb4883083248de422401a25ee97