### PR TITLE
Extract VisibilityLevel enum

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/data/model/PrivacySettings.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/data/model/PrivacySettings.kt
@@ -1,54 +1,75 @@
 package com.example.socialbatterymanager.data.model
 
 data class PrivacySettings(
-    val socialEnergyVisibility: VisibilityLevel = VisibilityLevel.FRIENDS,
+    val socialEnergyVisibility: VisibilityLevel = VisibilityLevel.FRIENDS_ONLY,
     val moodVisibility: VisibilityLevel = VisibilityLevel.CLOSE_FRIENDS,
     val activityVisibility: VisibilityLevel = VisibilityLevel.EVERYONE,
     val profileVisibility: VisibilityLevel = VisibilityLevel.EVERYONE
 )
-
-enum class VisibilityLevel {
-    EVERYONE,       // All contacts can see
-    FRIENDS,        // Friends and Close Friends can see
-    CLOSE_FRIENDS,  // Only Close Friends can see
-    PRIVATE         // Only user can see
-}
 
 object PrivacyManager {
 
     fun canViewSocialEnergy(viewerLabel: PersonLabel, privacySettings: PrivacySettings): Boolean {
         return when (privacySettings.socialEnergyVisibility) {
             VisibilityLevel.EVERYONE -> true
-            VisibilityLevel.FRIENDS -> viewerLabel in listOf(PersonLabel.FRIEND, PersonLabel.CLOSE_FRIEND, PersonLabel.FAMILY)
-            VisibilityLevel.CLOSE_FRIENDS -> viewerLabel in listOf(PersonLabel.CLOSE_FRIEND, PersonLabel.FAMILY)
-            VisibilityLevel.PRIVATE -> false
+            VisibilityLevel.FRIENDS_ONLY -> viewerLabel in listOf(
+                PersonLabel.FRIEND,
+                PersonLabel.CLOSE_FRIEND,
+                PersonLabel.FAMILY
+            )
+            VisibilityLevel.CLOSE_FRIENDS -> viewerLabel in listOf(
+                PersonLabel.CLOSE_FRIEND,
+                PersonLabel.FAMILY
+            )
+            VisibilityLevel.ONLY_ME -> false
         }
     }
 
     fun canViewMood(viewerLabel: PersonLabel, privacySettings: PrivacySettings): Boolean {
         return when (privacySettings.moodVisibility) {
             VisibilityLevel.EVERYONE -> true
-            VisibilityLevel.FRIENDS -> viewerLabel in listOf(PersonLabel.FRIEND, PersonLabel.CLOSE_FRIEND, PersonLabel.FAMILY)
-            VisibilityLevel.CLOSE_FRIENDS -> viewerLabel in listOf(PersonLabel.CLOSE_FRIEND, PersonLabel.FAMILY)
-            VisibilityLevel.PRIVATE -> false
+            VisibilityLevel.FRIENDS_ONLY -> viewerLabel in listOf(
+                PersonLabel.FRIEND,
+                PersonLabel.CLOSE_FRIEND,
+                PersonLabel.FAMILY
+            )
+            VisibilityLevel.CLOSE_FRIENDS -> viewerLabel in listOf(
+                PersonLabel.CLOSE_FRIEND,
+                PersonLabel.FAMILY
+            )
+            VisibilityLevel.ONLY_ME -> false
         }
     }
 
     fun canViewActivity(viewerLabel: PersonLabel, privacySettings: PrivacySettings): Boolean {
         return when (privacySettings.activityVisibility) {
             VisibilityLevel.EVERYONE -> true
-            VisibilityLevel.FRIENDS -> viewerLabel in listOf(PersonLabel.FRIEND, PersonLabel.CLOSE_FRIEND, PersonLabel.FAMILY)
-            VisibilityLevel.CLOSE_FRIENDS -> viewerLabel in listOf(PersonLabel.CLOSE_FRIEND, PersonLabel.FAMILY)
-            VisibilityLevel.PRIVATE -> false
+            VisibilityLevel.FRIENDS_ONLY -> viewerLabel in listOf(
+                PersonLabel.FRIEND,
+                PersonLabel.CLOSE_FRIEND,
+                PersonLabel.FAMILY
+            )
+            VisibilityLevel.CLOSE_FRIENDS -> viewerLabel in listOf(
+                PersonLabel.CLOSE_FRIEND,
+                PersonLabel.FAMILY
+            )
+            VisibilityLevel.ONLY_ME -> false
         }
     }
 
     fun canViewProfile(viewerLabel: PersonLabel, privacySettings: PrivacySettings): Boolean {
         return when (privacySettings.profileVisibility) {
             VisibilityLevel.EVERYONE -> true
-            VisibilityLevel.FRIENDS -> viewerLabel in listOf(PersonLabel.FRIEND, PersonLabel.CLOSE_FRIEND, PersonLabel.FAMILY)
-            VisibilityLevel.CLOSE_FRIENDS -> viewerLabel in listOf(PersonLabel.CLOSE_FRIEND, PersonLabel.FAMILY)
-            VisibilityLevel.PRIVATE -> false
+            VisibilityLevel.FRIENDS_ONLY -> viewerLabel in listOf(
+                PersonLabel.FRIEND,
+                PersonLabel.CLOSE_FRIEND,
+                PersonLabel.FAMILY
+            )
+            VisibilityLevel.CLOSE_FRIENDS -> viewerLabel in listOf(
+                PersonLabel.CLOSE_FRIEND,
+                PersonLabel.FAMILY
+            )
+            VisibilityLevel.ONLY_ME -> false
         }
     }
 }

--- a/app/src/main/java/com/example/socialbatterymanager/data/model/VisibilityLevel.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/data/model/VisibilityLevel.kt
@@ -1,0 +1,9 @@
+package com.example.socialbatterymanager.data.model
+
+enum class VisibilityLevel {
+    EVERYONE,      // All contacts can see
+    FRIENDS_ONLY,  // Friends and Close Friends can see
+    CLOSE_FRIENDS, // Only Close Friends can see
+    ONLY_ME        // Only user can see
+}
+

--- a/app/src/test/java/com/example/socialbatterymanager/features/people/PrivacyTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/features/people/PrivacyTest.kt
@@ -12,7 +12,7 @@ class PrivacyTest {
     @Test
     fun testSocialEnergyVisibility() {
         val settings = PrivacySettings(
-            socialEnergyVisibility = VisibilityLevel.FRIENDS
+            socialEnergyVisibility = VisibilityLevel.FRIENDS_ONLY
         )
 
         // Close friends should be able to see
@@ -60,8 +60,8 @@ class PrivacyTest {
     @Test
     fun testPrivateSettings() {
         val settings = PrivacySettings(
-            socialEnergyVisibility = VisibilityLevel.PRIVATE,
-            moodVisibility = VisibilityLevel.PRIVATE
+            socialEnergyVisibility = VisibilityLevel.ONLY_ME,
+            moodVisibility = VisibilityLevel.ONLY_ME
         )
 
         // No one should be able to see private information


### PR DESCRIPTION
## Summary
- add standalone `VisibilityLevel` enum for privacy levels
- update privacy model and tests to use new enum names

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689208f27fc483249b431ad3ce7b0c5e