### PR TITLE
Clarify types in peak usage analysis iteration

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/reports/ReportDataAnalyzer.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/reports/ReportDataAnalyzer.kt
@@ -82,7 +82,7 @@ class ReportDataAnalyzer {
             val totalActivities = activities.size.toFloat()
             val peakTimes = mutableListOf<PeakUsageTime>()
 
-            hourlyData.forEach { (hour, hourActivities) ->
+            hourlyData.forEach { (hour: Int, hourActivities: List<ActivityEntity>) ->
                 val avgEnergy = hourActivities.map { it.energy }.average()
                 val percentage = (hourActivities.size / totalActivities) * 100
 


### PR DESCRIPTION
## Summary
- Specify `Int` and `List<ActivityEntity>` types when iterating over grouped hourly data in `ReportDataAnalyzer`.

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew detekt` *(fails: could not resolve detekt dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6892091de730832490dfe236b7850060