### PR TITLE
Add notifications button to home header

### DIFF
--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -32,10 +32,13 @@
                 android:textStyle="bold"
                 android:textColor="@android:color/white" />
 
-            <View
+            <ImageButton
+                android:id="@+id/btnNotifications"
                 android:layout_width="32dp"
                 android:layout_height="32dp"
-                android:background="@android:color/darker_gray" />
+                android:background="@android:color/transparent"
+                android:contentDescription="@string/notifications"
+                app:srcCompat="@drawable/ic_notifications" />
 
         </LinearLayout>
 

--- a/app/src/test/java/com/example/socialbatterymanager/features/home/SimpleHomeFragmentTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/features/home/SimpleHomeFragmentTest.kt
@@ -1,12 +1,14 @@
 package com.example.socialbatterymanager.features.home
 
 import android.widget.Button
+import android.widget.ImageButton
 import android.widget.TextView
+import androidx.navigation.NavController
+import androidx.navigation.Navigation
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.socialbatterymanager.R
 import com.example.socialbatterymanager.features.home.ui.SimpleHomeFragment
 import com.example.socialbatterymanager.features.notifications.NotificationService
-import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Assert.assertEquals
@@ -51,5 +53,19 @@ class SimpleHomeFragmentTest {
 
         assertEquals("60%", tvEnergy.text.toString())
         verify { mockService.checkAndGenerateEnergyLowNotification(60) }
+    }
+
+    @Test
+    fun clickingNotifications_navigatesToNotifications() {
+        val controller = Robolectric.buildFragment(SimpleHomeFragment::class.java).create().start().resume()
+        val fragment = controller.get()
+
+        val navController = mockk<NavController>(relaxed = true)
+        Navigation.setViewNavController(fragment.requireView(), navController)
+
+        val btnNotifications = fragment.requireView().findViewById<ImageButton>(R.id.btnNotifications)
+        btnNotifications.performClick()
+
+        verify { navController.navigate(R.id.action_homeFragment_to_notificationsFragment) }
     }
 }


### PR DESCRIPTION
## Summary
- Replace placeholder header view with a notifications `ImageButton`
- Add Robolectric test verifying notifications button navigates to notifications screen

## Testing
- `./gradlew ktlintCheck detekt testDebugUnitTest` *(fails: SDK location not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68920927938c8324aa629ed3be51bc3a