### PR TITLE
Rename energy level TextView to tvEnergyPercentage

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/features/home/ui/SimpleHomeFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/home/ui/SimpleHomeFragment.kt
@@ -25,7 +25,7 @@ class SimpleHomeFragment : Fragment() {
     private lateinit var btnRemoveEnergy: Button
     private lateinit var btnTestBattery: Button
     private lateinit var tvWeeklyStats: TextView
-    private lateinit var tvEnergyLevel: TextView
+    private lateinit var tvEnergyPercentage: TextView
     private lateinit var notificationService: NotificationService
 
     private val viewModel: SimpleHomeViewModel by viewModels()
@@ -49,7 +49,7 @@ class SimpleHomeFragment : Fragment() {
         btnRemoveEnergy = view.findViewById(R.id.btnRemoveEnergy)
         btnTestBattery = view.findViewById(R.id.btnTestBattery)
         tvWeeklyStats = view.findViewById(R.id.tvWeeklyStats)
-        tvEnergyLevel = view.findViewById(R.id.tvEnergyLevel)
+        tvEnergyPercentage = view.findViewById(R.id.tvEnergyPercentage)
 
         setupClickListeners()
         if (BuildConfig.DEBUG) {
@@ -89,7 +89,7 @@ class SimpleHomeFragment : Fragment() {
         currentEnergyLevel = newLevel
         
         // Update UI
-        tvEnergyLevel.text = "$newLevel%"
+        tvEnergyPercentage.text = "$newLevel%"
         
         // Check if we should generate a low energy notification
         notificationService.checkAndGenerateEnergyLowNotification(newLevel)

--- a/app/src/test/java/com/example/socialbatterymanager/features/home/SimpleHomeFragmentTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/features/home/SimpleHomeFragmentTest.kt
@@ -27,7 +27,7 @@ class SimpleHomeFragmentTest {
         field.set(fragment, mockService)
 
         val btnAdd = fragment.requireView().findViewById<Button>(R.id.btnAddEnergy)
-        val tvEnergy = fragment.requireView().findViewById<TextView>(R.id.tvEnergyLevel)
+        val tvEnergy = fragment.requireView().findViewById<TextView>(R.id.tvEnergyPercentage)
 
         btnAdd.performClick()
 
@@ -45,7 +45,7 @@ class SimpleHomeFragmentTest {
         field.set(fragment, mockService)
 
         val btnRemove = fragment.requireView().findViewById<Button>(R.id.btnRemoveEnergy)
-        val tvEnergy = fragment.requireView().findViewById<TextView>(R.id.tvEnergyLevel)
+        val tvEnergy = fragment.requireView().findViewById<TextView>(R.id.tvEnergyPercentage)
 
         btnRemove.performClick()
 


### PR DESCRIPTION
## Summary
- rename tvEnergyLevel to tvEnergyPercentage in SimpleHomeFragment
- update tests to reference tvEnergyPercentage view

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68920927af0483248e3753830fa6a138