### PR TITLE
Fix numeric type mixing in energy calculations

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/data/model/CalendarActivityEvent.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/data/model/CalendarActivityEvent.kt
@@ -44,7 +44,7 @@ data class CalendarActivityEvent(
      * Calculate energy burn based on duration and activity type
      */
     fun calculateEnergyBurn(): Double {
-        val durationHours = (endTime - startTime) / (1000.0 * 60 * 60)
+        val durationHours = (endTime.toDouble() - startTime.toDouble()) / (1000 * 60 * 60).toDouble()
         val baseRate = when (activityType.lowercase()) {
             "meeting" -> 1.5
             "presentation" -> 2.0

--- a/app/src/main/java/com/example/socialbatterymanager/features/energy/EnergyManager.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/energy/EnergyManager.kt
@@ -121,24 +121,24 @@ class EnergyManager {
                     id = 1,
                     title = "Team Meeting",
                     description = "Weekly standup with development team",
-                    startTime = todayStart + (9 * 60 * 60 * 1000), // 9:00 AM
-                    endTime = todayStart + (10.5 * 60 * 60 * 1000), // 10:30 AM
+                    startTime = todayStart + (9 * 60 * 60 * 1000L), // 9:00 AM
+                    endTime = todayStart + (10.5 * 60 * 60 * 1000).toLong(), // 10:30 AM
                     source = "google",
                 ),
                 CalendarEvent(
                     id = 2,
                     title = "Lunch with Sarah",
                     description = "Catching up with close friend",
-                    startTime = todayStart + (12 * 60 * 60 * 1000), // 12:00 PM
-                    endTime = todayStart + (13 * 60 * 60 * 1000), // 1:00 PM
+                    startTime = todayStart + (12 * 60 * 60 * 1000L), // 12:00 PM
+                    endTime = todayStart + (13 * 60 * 60 * 1000L), // 1:00 PM
                     source = "manual",
                 ),
                 CalendarEvent(
                     id = 3,
                     title = "Client Presentation",
                     description = "Important project presentation",
-                    startTime = todayStart + (15 * 60 * 60 * 1000), // 3:00 PM
-                    endTime = todayStart + (16.5 * 60 * 60 * 1000), // 4:30 PM
+                    startTime = todayStart + (15 * 60 * 60 * 1000L), // 3:00 PM
+                    endTime = todayStart + (16.5 * 60 * 60 * 1000).toLong(), // 4:30 PM
                     source = "outlook",
                 )
             )

--- a/app/src/test/java/com/example/socialbatterymanager/data/model/CalendarActivityEventTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/data/model/CalendarActivityEventTest.kt
@@ -12,7 +12,7 @@ class CalendarActivityEventTest {
             title = "Team Meeting",
             description = "Weekly standup",
             startTime = System.currentTimeMillis(),
-            endTime = System.currentTimeMillis() + (60 * 60 * 1000), // 1 hour later
+            endTime = System.currentTimeMillis() + (60 * 60 * 1000L), // 1 hour later
             location = "Conference Room",
             source = "google"
         )
@@ -31,7 +31,7 @@ class CalendarActivityEventTest {
     @Test
     fun `calculateEnergyBurn returns correct values for different activity types`() {
         val baseTime = System.currentTimeMillis()
-        val oneHourLater = baseTime + (60 * 60 * 1000)
+        val oneHourLater = baseTime + (60 * 60 * 1000L)
         
         // Meeting activity
         val meetingEvent = CalendarActivityEvent(
@@ -111,9 +111,9 @@ class CalendarActivityEventTest {
     @Test
     fun `getColorIndicator returns correct colors for energy levels`() {
         val baseTime = System.currentTimeMillis()
-        val thirtyMinutes = baseTime + (30 * 60 * 1000)
-        val oneHour = baseTime + (60 * 60 * 1000)
-        val twoHours = baseTime + (2 * 60 * 60 * 1000)
+        val thirtyMinutes = baseTime + (30 * 60 * 1000L)
+        val oneHour = baseTime + (60 * 60 * 1000L)
+        val twoHours = baseTime + (2 * 60 * 60 * 1000L)
         
         // Low energy activity (should be green)
         val lowEnergyEvent = CalendarActivityEvent(


### PR DESCRIPTION
## Summary
- eliminate mixed Double/Long arithmetic in sample event times
- ensure CalendarActivityEvent energy burn uses Double math
- update tests to use Long offsets for time calculations

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689209470ecc8324b9c6ba86fc5e608f