### PR TITLE
Use ListenableFuture for async sync state check

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,6 +78,7 @@ dependencies {
     implementation(libs.androidx.biometric)
     implementation(libs.androidx.security.crypto)
     implementation(libs.androidx.sqlite.framework)
+    implementation("androidx.concurrent:concurrent-futures:1.1.0")
     implementation("com.google.android.material:material:1.11.0")
     implementation("androidx.cardview:cardview:1.0.0")
 


### PR DESCRIPTION
## Summary
- switch sync status lookup to `ListenableFuture` using `CallbackToFutureAdapter`
- add AndroidX concurrent futures dependency

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68920947c9608324abe665655218226b