### PR TITLE
chore: align requirements processor Kotlin versions

### DIFF
--- a/requirements-processor/build.gradle.kts
+++ b/requirements-processor/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    kotlin("jvm") version "1.8.10"
-    kotlin("plugin.serialization") version "1.8.10"
+    kotlin("jvm") version "1.9.0"
+    kotlin("plugin.serialization") version "1.9.0"
     application
 }
 
@@ -12,12 +12,12 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
-    
-    testImplementation("org.jetbrains.kotlin:kotlin-test")
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
+
+    testImplementation("org.jetbrains.kotlin:kotlin-test:1.9.0")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:1.9.0")
     testImplementation("junit:junit:4.13.2")
 }
 

--- a/requirements-processor/settings.gradle.kts
+++ b/requirements-processor/settings.gradle.kts
@@ -1,1 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = "requirements-processor"


### PR DESCRIPTION
## Summary
- bump Kotlin JVM and serialization plugins to 1.9.0 in requirements processor
- align kotlin-stdlib and test libraries with the same Kotlin version
- configure plugin repositories for requirements processor

## Testing
- `./gradlew clean build` *(fails: SDK location not found)*
- `(cd requirements-processor && ./gradlew clean build)` *(fails: plugin org.jetbrains.kotlin.jvm 1.9.0 not found; repository returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_68923a90c5488324985a054d6ab3ca9b