### PR TITLE
chore: align serialization plugin and dependencies

### DIFF
--- a/requirements-processor/build.gradle.kts
+++ b/requirements-processor/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    kotlin("jvm") version "1.8.10"
-    kotlin("plugin.serialization") version "1.8.10"
+    kotlin("jvm") version "1.9.24"
+    kotlin("plugin.serialization") version "1.9.24"
     application
 }
 
@@ -13,8 +13,8 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
     
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")


### PR DESCRIPTION
## Summary
- align requirements-processor module with Kotlin serialization plugin and json dependency versions

## Testing
- `./gradlew test` *(fails: Plugin [id: 'org.jetbrains.kotlin.jvm', version: '1.9.24'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68923a913db4832486c8762a26f14f90