### PR TITLE
Pin Kotlin stdlib versions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,6 +60,9 @@ android {
 }
 
 dependencies {
+    // Kotlin
+    implementation(kotlin("stdlib", "1.9.24"))
+
     // Lottie
     implementation("com.airbnb.android:lottie:6.4.0")
 

--- a/requirements-processor/build.gradle.kts
+++ b/requirements-processor/build.gradle.kts
@@ -12,12 +12,12 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib")
+    implementation(kotlin("stdlib", "1.8.10"))
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
-    
-    testImplementation("org.jetbrains.kotlin:kotlin-test")
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
+
+    testImplementation(kotlin("test", "1.8.10"))
+    testImplementation(kotlin("test-junit", "1.8.10"))
     testImplementation("junit:junit:4.13.2")
 }
 


### PR DESCRIPTION
## Summary
- pin Kotlin stdlib in app module to the compiler version
- ensure requirements-processor uses explicit Kotlin stdlib and test libs

## Testing
- `./gradlew clean` *(fails: Could not download kotlin-stdlib-jdk8-1.9.20.jar... Received status code 403)*
- `./gradlew build --refresh-dependencies` *(fails: Plugin [id: 'com.android.application', version: '8.4.1', apply: false] was not found...)*

------
https://chatgpt.com/codex/tasks/task_e_68923a91cb9c8324979cc96ca32b82a7