### PR TITLE
Inject NotificationService via Hilt with preference-aware checks

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/di/AppModule.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/di/AppModule.kt
@@ -3,6 +3,7 @@ package com.example.socialbatterymanager.di
 import android.content.Context
 import com.example.socialbatterymanager.data.database.AppDatabase
 import com.example.socialbatterymanager.data.repository.SecurityManager
+import com.example.socialbatterymanager.shared.preferences.PreferencesManager
 import com.google.gson.Gson
 import dagger.Module
 import dagger.Provides
@@ -37,4 +38,10 @@ class AppModule {
     @Provides
     @Singleton
     fun provideGson(): Gson = Gson()
+
+    @Provides
+    @Singleton
+    fun providePreferencesManager(
+        @ApplicationContext context: Context,
+    ): PreferencesManager = PreferencesManager(context)
 }

--- a/app/src/main/java/com/example/socialbatterymanager/di/CoroutinesModule.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/di/CoroutinesModule.kt
@@ -1,0 +1,26 @@
+package com.example.socialbatterymanager.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Qualifier
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ApplicationScope
+
+@Module
+@InstallIn(SingletonComponent::class)
+object CoroutinesModule {
+    @Provides
+    @Singleton
+    @ApplicationScope
+    fun provideApplicationScope(): CoroutineScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.IO)
+}
+

--- a/app/src/main/java/com/example/socialbatterymanager/features/home/ui/SimpleHomeFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/home/ui/SimpleHomeFragment.kt
@@ -15,6 +15,7 @@ import com.example.socialbatterymanager.R
 import com.example.socialbatterymanager.databinding.FragmentHomeBinding
 import com.example.socialbatterymanager.features.notifications.NotificationService
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
@@ -26,7 +27,7 @@ class SimpleHomeFragment : Fragment() {
     private lateinit var btnTestBattery: Button
     private lateinit var tvWeeklyStats: TextView
     private lateinit var tvEnergyPercentage: TextView
-    private lateinit var notificationService: NotificationService
+    @Inject lateinit var notificationService: NotificationService
 
     private val viewModel: SimpleHomeViewModel by viewModels()
 
@@ -42,9 +43,6 @@ class SimpleHomeFragment : Fragment() {
         savedInstanceState: Bundle?,
     ): View {
         _binding = FragmentHomeBinding.inflate(inflater, container, false)
-
-        // Initialize notification service
-        notificationService = NotificationService(requireContext())
 
         // Initialize views
         btnNotifications = requireView().findViewById(R.id.btnNotifications)

--- a/app/src/main/java/com/example/socialbatterymanager/features/notifications/NotificationService.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/notifications/NotificationService.kt
@@ -6,19 +6,31 @@ import com.example.socialbatterymanager.R
 import com.example.socialbatterymanager.data.database.AppDatabase
 import com.example.socialbatterymanager.data.model.NotificationEntity
 import com.example.socialbatterymanager.data.model.NotificationType
+import com.example.socialbatterymanager.di.ApplicationScope
+import com.example.socialbatterymanager.shared.preferences.PreferencesManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 
-class NotificationService(private val context: Context) {
-    
-    private val database = AppDatabase.getDatabase(context)
-    private val scope = CoroutineScope(Dispatchers.IO)
+@Singleton
+class NotificationService @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val database: AppDatabase,
+    private val preferencesManager: PreferencesManager,
+    @ApplicationScope private val scope: CoroutineScope,
+) {
+
+    private suspend fun notificationsEnabled(): Boolean =
+        preferencesManager.notificationsEnabledFlow.first()
     
     fun generateSampleNotifications() {
         if (BuildConfig.DEBUG) {
             scope.launch {
+                if (!notificationsEnabled()) return@launch
+
                 // Retrieve current notifications to avoid duplicate inserts
                 val existingNotifications =
                     database.notificationDao().getAllNotifications().first()
@@ -29,22 +41,31 @@ class NotificationService(private val context: Context) {
                         NotificationEntity(
                             type = NotificationType.ENERGY_LOW.name,
                             title = context.getString(R.string.notification_energy_low_title),
-                            message = context.getString(R.string.notification_energy_low_sample_message),
-                            timestamp = System.currentTimeMillis() - (2 * 60 * 1000) // 2 minutes ago
+                            message =
+                                context.getString(
+                                    R.string.notification_energy_low_sample_message
+                                ),
+                            timestamp = System.currentTimeMillis() - (2 * 60 * 1000), // 2 minutes ago
                         ),
                         NotificationEntity(
                             type = NotificationType.BUSY_WEEK.name,
                             title = context.getString(R.string.notification_busy_week_title),
-                            message = context.getString(R.string.notification_busy_week_sample_message),
-                            timestamp = System.currentTimeMillis() - (60 * 60 * 1000) // 1 hour ago
+                            message =
+                                context.getString(
+                                    R.string.notification_busy_week_sample_message
+                                ),
+                            timestamp = System.currentTimeMillis() - (60 * 60 * 1000), // 1 hour ago
                         ),
                         NotificationEntity(
                             type = NotificationType.RATE_ACTIVITY.name,
                             title = context.getString(R.string.notification_rate_activity_title),
-                            message = context.getString(R.string.notification_rate_activity_sample_message),
+                            message =
+                                context.getString(
+                                    R.string.notification_rate_activity_sample_message
+                                ),
                             timestamp = System.currentTimeMillis() - (3 * 60 * 60 * 1000), // 3 hours ago
-                            activityId = 1 // Assuming there's an activity with ID 1
-                        )
+                            activityId = 1, // Assuming there's an activity with ID 1
+                        ),
                     )
 
                     notifications.forEach { notification ->
@@ -54,41 +75,59 @@ class NotificationService(private val context: Context) {
             }
         }
     }
-    
+
     fun checkAndGenerateEnergyLowNotification(currentEnergyLevel: Int) {
         if (currentEnergyLevel <= 30) {
             scope.launch {
+                if (!notificationsEnabled()) return@launch
+
                 val notification = NotificationEntity(
                     type = NotificationType.ENERGY_LOW.name,
                     title = context.getString(R.string.notification_energy_low_title),
-                    message = context.getString(R.string.notification_energy_low_message, currentEnergyLevel),
-                    timestamp = System.currentTimeMillis()
+                    message =
+                        context.getString(
+                            R.string.notification_energy_low_message,
+                            currentEnergyLevel,
+                        ),
+                    timestamp = System.currentTimeMillis(),
                 )
                 database.notificationDao().insertNotification(notification)
             }
         }
     }
-    
+
     fun generateActivityRatingNotification(activityId: Int, activityName: String) {
         scope.launch {
+            if (!notificationsEnabled()) return@launch
+
             val notification = NotificationEntity(
                 type = NotificationType.RATE_ACTIVITY.name,
                 title = context.getString(R.string.notification_rate_activity_title),
-                message = context.getString(R.string.notification_rate_activity_message, activityName),
+                message =
+                    context.getString(
+                        R.string.notification_rate_activity_message,
+                        activityName,
+                    ),
                 timestamp = System.currentTimeMillis(),
-                activityId = activityId
+                activityId = activityId,
             )
             database.notificationDao().insertNotification(notification)
         }
     }
-    
+
     fun generateBusyWeekNotification(activitiesCount: Int) {
         scope.launch {
+            if (!notificationsEnabled()) return@launch
+
             val notification = NotificationEntity(
                 type = NotificationType.BUSY_WEEK.name,
                 title = context.getString(R.string.notification_busy_week_title),
-                message = context.getString(R.string.notification_busy_week_message, activitiesCount),
-                timestamp = System.currentTimeMillis()
+                message =
+                    context.getString(
+                        R.string.notification_busy_week_message,
+                        activitiesCount,
+                    ),
+                timestamp = System.currentTimeMillis(),
             )
             database.notificationDao().insertNotification(notification)
         }

--- a/app/src/test/java/com/example/socialbatterymanager/features/home/SimpleHomeFragmentTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/features/home/SimpleHomeFragmentTest.kt
@@ -6,11 +6,17 @@ import android.widget.ImageButton
 import android.widget.TextView
 import androidx.navigation.NavController
 import androidx.navigation.Navigation
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.socialbatterymanager.R
 import com.example.socialbatterymanager.features.home.ui.SimpleHomeFragment
 import com.example.socialbatterymanager.features.notifications.NotificationService
+import com.example.socialbatterymanager.data.database.AppDatabase
+import com.example.socialbatterymanager.shared.preferences.PreferencesManager
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -21,12 +27,21 @@ class SimpleHomeFragmentTest {
 
     @Test
     fun clickingAddEnergy_updatesLevelAndNotifies() {
-        val controller = Robolectric.buildFragment(SimpleHomeFragment::class.java).create().start().resume()
+        val controller = Robolectric.buildFragment(SimpleHomeFragment::class.java)
         val fragment = controller.get()
-        val mockService = mockk<NotificationService>(relaxed = true, constructorArgs = arrayOf(fragment.requireContext()))
+        val mockService = mockk<NotificationService>(
+            relaxed = true,
+            constructorArgs = arrayOf(
+                ApplicationProvider.getApplicationContext(),
+                mockk<AppDatabase>(relaxed = true),
+                mockk<PreferencesManager>(relaxed = true),
+                CoroutineScope(Dispatchers.Unconfined)
+            )
+        )
         val field = SimpleHomeFragment::class.java.getDeclaredField("notificationService")
         field.isAccessible = true
         field.set(fragment, mockService)
+        controller.create().start().resume()
         val btnAdd = fragment.requireView().findViewById<Button>(R.id.btnAddEnergy)
         val tvEnergy = fragment.requireView().findViewById<TextView>(R.id.tvEnergyPercentage)
         btnAdd.performClick()
@@ -37,12 +52,21 @@ class SimpleHomeFragmentTest {
 
     @Test
     fun clickingRemoveEnergy_updatesLevelAndNotifies() {
-        val controller = Robolectric.buildFragment(SimpleHomeFragment::class.java).create().start().resume()
+        val controller = Robolectric.buildFragment(SimpleHomeFragment::class.java)
         val fragment = controller.get()
-        val mockService = mockk<NotificationService>(relaxed = true, constructorArgs = arrayOf(fragment.requireContext()))
+        val mockService = mockk<NotificationService>(
+            relaxed = true,
+            constructorArgs = arrayOf(
+                ApplicationProvider.getApplicationContext(),
+                mockk<AppDatabase>(relaxed = true),
+                mockk<PreferencesManager>(relaxed = true),
+                CoroutineScope(Dispatchers.Unconfined)
+            )
+        )
         val field = SimpleHomeFragment::class.java.getDeclaredField("notificationService")
         field.isAccessible = true
         field.set(fragment, mockService)
+        controller.create().start().resume()
         val btnRemove = fragment.requireView().findViewById<Button>(R.id.btnRemoveEnergy)
         val tvEnergy = fragment.requireView().findViewById<TextView>(R.id.tvEnergyPercentage)
         btnRemove.performClick()
@@ -53,8 +77,21 @@ class SimpleHomeFragmentTest {
 
     @Test
     fun clickingNotifications_navigatesToNotifications() {
-        val controller = Robolectric.buildFragment(SimpleHomeFragment::class.java).create().start().resume()
+        val controller = Robolectric.buildFragment(SimpleHomeFragment::class.java)
         val fragment = controller.get()
+        val mockService = mockk<NotificationService>(
+            relaxed = true,
+            constructorArgs = arrayOf(
+                ApplicationProvider.getApplicationContext(),
+                mockk<AppDatabase>(relaxed = true),
+                mockk<PreferencesManager>(relaxed = true),
+                CoroutineScope(Dispatchers.Unconfined)
+            )
+        )
+        val field = SimpleHomeFragment::class.java.getDeclaredField("notificationService")
+        field.isAccessible = true
+        field.set(fragment, mockService)
+        controller.create().start().resume()
 
         val navController = mockk<NavController>(relaxed = true)
         Navigation.setViewNavController(fragment.requireView(), navController)

--- a/app/src/test/java/com/example/socialbatterymanager/features/notifications/NotificationServiceTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/features/notifications/NotificationServiceTest.kt
@@ -1,0 +1,71 @@
+package com.example.socialbatterymanager.features.notifications
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.socialbatterymanager.data.database.AppDatabase
+import com.example.socialbatterymanager.data.database.NotificationDao
+import com.example.socialbatterymanager.shared.preferences.PreferencesManager
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.flow.first
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import androidx.room.Room
+
+@RunWith(AndroidJUnit4::class)
+class NotificationServiceTest {
+    private lateinit var database: AppDatabase
+    private lateinit var dao: NotificationDao
+    private lateinit var preferences: PreferencesManager
+    private lateinit var scope: TestScope
+    private lateinit var service: NotificationService
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        database = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = database.notificationDao()
+        preferences = mockk(relaxed = true)
+        scope = TestScope(UnconfinedTestDispatcher())
+        service = NotificationService(
+            context,
+            database,
+            preferences,
+            scope
+        )
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun insertsNotificationWhenEnabled() = runTest {
+        every { preferences.notificationsEnabledFlow } returns flowOf(true)
+        service.checkAndGenerateEnergyLowNotification(10)
+        scope.advanceUntilIdle()
+        val notifications = dao.getAllNotifications().first()
+        assertEquals(1, notifications.size)
+    }
+
+    @Test
+    fun doesNotInsertNotificationWhenDisabled() = runTest {
+        every { preferences.notificationsEnabledFlow } returns flowOf(false)
+        service.checkAndGenerateEnergyLowNotification(10)
+        scope.advanceUntilIdle()
+        val notifications = dao.getAllNotifications().first()
+        assertEquals(0, notifications.size)
+    }
+}
+


### PR DESCRIPTION
## Summary
- Convert `NotificationService` into a Hilt `@Singleton` that receives `AppDatabase`, `PreferencesManager`, and an `@ApplicationScope` `CoroutineScope`
- Provide an `ApplicationScope` coroutine module and Hilt binding for `PreferencesManager`
- Update `SimpleHomeFragment` and tests to use injected service and add unit tests covering notification preferences

## Testing
- `./gradlew test` *(fails: In version catalog libs, you can only call the 'from' method a single time)*

------
https://chatgpt.com/codex/tasks/task_e_6894d67a57888324904503f1d51287dd