### PR TITLE
Introduce ProfileViewModel for profile data and actions

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/features/profile/ui/ProfileViewModel.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/profile/ui/ProfileViewModel.kt
@@ -1,0 +1,125 @@
+package com.example.socialbatterymanager.features.profile.ui
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.socialbatterymanager.R
+import com.example.socialbatterymanager.data.model.User
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+val Context.profileDataStore: DataStore<Preferences> by preferencesDataStore(name = "profile_preferences")
+
+@HiltViewModel
+class ProfileViewModel @Inject constructor(
+    @ApplicationContext private val context: Context
+) : ViewModel() {
+
+    private val dataStore = context.profileDataStore
+
+    private val NAME_KEY = stringPreferencesKey("user_name")
+    private val EMAIL_KEY = stringPreferencesKey("user_email")
+    private val CAPACITY_KEY = intPreferencesKey("battery_capacity")
+    private val WARNING_KEY = intPreferencesKey("warning_level")
+    private val NOTIFICATIONS_KEY = booleanPreferencesKey("notifications_enabled")
+    private val MOOD_KEY = stringPreferencesKey("current_mood")
+    private val PHOTO_KEY = stringPreferencesKey("profile_photo")
+
+    private val _user = MutableStateFlow(
+        User(
+            id = "1",
+            name = context.getString(R.string.default_user_name),
+            email = context.getString(R.string.default_user_email),
+            batteryCapacity = 100,
+            warningLevel = 30,
+            currentMood = context.getString(R.string.default_mood),
+            notificationsEnabled = true
+        )
+    )
+    val user: StateFlow<User> = _user.asStateFlow()
+
+    init {
+        loadUserProfile()
+    }
+
+    private fun loadUserProfile() {
+        viewModelScope.launch {
+            dataStore.data.map { preferences ->
+                User(
+                    id = "1",
+                    name = preferences[NAME_KEY] ?: context.getString(R.string.default_user_name),
+                    email = preferences[EMAIL_KEY] ?: context.getString(R.string.default_user_email),
+                    photoUri = preferences[PHOTO_KEY],
+                    batteryCapacity = preferences[CAPACITY_KEY] ?: 100,
+                    warningLevel = preferences[WARNING_KEY] ?: 30,
+                    currentMood = preferences[MOOD_KEY] ?: context.getString(R.string.default_mood),
+                    notificationsEnabled = preferences[NOTIFICATIONS_KEY] ?: true
+                )
+            }.collect { user ->
+                _user.value = user
+            }
+        }
+    }
+
+    fun saveProfile(
+        name: String,
+        email: String,
+        capacity: Int,
+        warning: Int,
+        notificationsEnabled: Boolean,
+        mood: String
+    ) {
+        viewModelScope.launch {
+            dataStore.edit { preferences ->
+                preferences[NAME_KEY] = name
+                preferences[EMAIL_KEY] = email
+                preferences[CAPACITY_KEY] = capacity
+                preferences[WARNING_KEY] = warning
+                preferences[NOTIFICATIONS_KEY] = notificationsEnabled
+                preferences[MOOD_KEY] = mood
+            }
+        }
+    }
+
+    fun saveImageUri(uri: String) {
+        viewModelScope.launch {
+            dataStore.edit { preferences ->
+                preferences[PHOTO_KEY] = uri
+            }
+        }
+    }
+
+    fun signOut() {
+        viewModelScope.launch {
+            dataStore.edit { it.clear() }
+        }
+    }
+
+    fun deleteAccount() {
+        viewModelScope.launch {
+            dataStore.edit { it.clear() }
+        }
+    }
+
+    fun recalibrate() {
+        viewModelScope.launch {
+            dataStore.edit { preferences ->
+                preferences[CAPACITY_KEY] = 100
+                preferences[WARNING_KEY] = 30
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/example/socialbatterymanager/features/profile/ui/ProfileViewModelTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/features/profile/ui/ProfileViewModelTest.kt
@@ -1,0 +1,73 @@
+package com.example.socialbatterymanager.features.profile.ui
+
+import android.content.Context
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.test.core.app.ApplicationProvider
+import com.example.socialbatterymanager.data.model.User
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProfileViewModelTest {
+
+    @get:Rule
+    val instantRule = InstantTaskExecutorRule()
+
+    private val dispatcher = StandardTestDispatcher()
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        context = ApplicationProvider.getApplicationContext()
+        runBlocking {
+            context.profileDataStore.edit { it.clear() }
+        }
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun saveProfile_updatesUserState() = runTest {
+        val viewModel = ProfileViewModel(context)
+
+        viewModel.saveProfile("John Doe", "john@example.com", 80, 20, true, "happy")
+        advanceUntilIdle()
+
+        val user: User = viewModel.user.value
+        assertEquals("John Doe", user.name)
+        assertEquals("john@example.com", user.email)
+        assertEquals(80, user.batteryCapacity)
+        assertEquals(20, user.warningLevel)
+        assertEquals(true, user.notificationsEnabled)
+        assertEquals("happy", user.currentMood)
+    }
+
+    @Test
+    fun recalibrate_resetsCapacityAndWarning() = runTest {
+        val viewModel = ProfileViewModel(context)
+        viewModel.saveProfile("Jane", "jane@example.com", 60, 25, true, "tired")
+        advanceUntilIdle()
+
+        viewModel.recalibrate()
+        advanceUntilIdle()
+
+        val user = viewModel.user.value
+        assertEquals(100, user.batteryCapacity)
+        assertEquals(30, user.warningLevel)
+    }
+}


### PR DESCRIPTION
## Summary
- Centralize profile persistence and actions in new `ProfileViewModel`
- Observe ViewModel state in `ProfileFragment` and remove unused `SharedPreferences`
- Test profile save and recalibration logic

## Testing
- `./gradlew test` *(fails: Invalid catalog definition: In version catalog libs, you can only call the 'from' method a single time.)*
- `./gradlew ktlintCheck` *(fails: Invalid catalog definition: In version catalog libs, you can only call the 'from' method a single time.)*

------
https://chatgpt.com/codex/tasks/task_e_6894d67dbac08324a11f39e08d768de0