### PR TITLE
Use document IDs for Firebase sync and add tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -118,6 +118,7 @@ dependencies {
     testImplementation(libs.findLibrary("kotlinx-coroutines-test").get())
     testImplementation(libs.findLibrary("mockk").get())
     testImplementation(libs.findLibrary("robolectric").get())
+    testImplementation(libs.findLibrary("work-testing").get())
     androidTestImplementation(libs.findLibrary("androidx-test-junit").get())
     androidTestImplementation(libs.findLibrary("androidx-test-espresso").get())
     androidTestImplementation(platform(libs.findLibrary("compose-bom").get()))

--- a/app/src/main/java/com/example/socialbatterymanager/data/database/ActivityDao.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/data/database/ActivityDao.kt
@@ -22,6 +22,9 @@ interface ActivityDao {
     
     @Query("SELECT * FROM activities WHERE id = :id AND isDeleted = 0")
     suspend fun getActivityById(id: Int): ActivityEntity?
+
+    @Query("SELECT * FROM activities WHERE firebaseId = :firebaseId AND isDeleted = 0")
+    suspend fun getActivityByFirebaseId(firebaseId: String): ActivityEntity?
     
     @Query("UPDATE activities SET isDeleted = 1, updatedAt = :timestamp WHERE id = :id")
     suspend fun softDeleteActivity(id: Int, timestamp: Long = System.currentTimeMillis())

--- a/app/src/test/java/com/example/socialbatterymanager/data/repository/DataRepositoryAuditBackupTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/data/repository/DataRepositoryAuditBackupTest.kt
@@ -25,6 +25,7 @@ private class FakeActivityDao : ActivityDao {
     }
     override fun getAllActivities(): Flow<List<ActivityEntity>> = MutableStateFlow(activities.toList())
     override suspend fun getActivityById(id: Int): ActivityEntity? = activities.find { it.id == id }
+    override suspend fun getActivityByFirebaseId(firebaseId: String): ActivityEntity? = activities.find { it.firebaseId == firebaseId }
     override suspend fun softDeleteActivity(id: Int, timestamp: Long) {
         val index = activities.indexOfFirst { it.id == id }
         if (index >= 0) {

--- a/app/src/test/java/com/example/socialbatterymanager/features/home/HomeRepositoryTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/features/home/HomeRepositoryTest.kt
@@ -19,6 +19,7 @@ private class FakeActivityDao(private val count: Int) : ActivityDao {
     override suspend fun updateActivity(activity: ActivityEntity) = throw NotImplementedError()
     override fun getAllActivities(): Flow<List<ActivityEntity>> = throw NotImplementedError()
     override suspend fun getActivityById(id: Int): ActivityEntity? = throw NotImplementedError()
+    override suspend fun getActivityByFirebaseId(firebaseId: String): ActivityEntity? = throw NotImplementedError()
     override suspend fun softDeleteActivity(id: Int, timestamp: Long) = throw NotImplementedError()
     override suspend fun deleteActivity(activity: ActivityEntity) = throw NotImplementedError()
     override suspend fun getAllActivitiesForBackup(): List<ActivityEntity> = throw NotImplementedError()

--- a/app/src/test/java/com/example/socialbatterymanager/sync/SyncWorkerFirebaseTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/sync/SyncWorkerFirebaseTest.kt
@@ -1,0 +1,141 @@
+package com.example.socialbatterymanager.sync
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.ListenableWorker
+import androidx.work.WorkerParameters
+import androidx.work.testing.TestListenableWorkerBuilder
+import com.example.socialbatterymanager.data.database.AppDatabase
+import com.example.socialbatterymanager.shared.utils.NetworkStatusProvider
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
+import com.google.firebase.firestore.QuerySnapshot
+import io.mockk.any
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+private class ConnectedNetworkManager : NetworkStatusProvider {
+    override fun isCurrentlyConnected(): Boolean = true
+    override fun unregister() {}
+}
+
+class SyncWorkerFirebaseTest {
+    private lateinit var context: Context
+    private lateinit var db: AppDatabase
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    private fun buildWorker(vararg documents: DocumentSnapshot): SyncWorker {
+        val firestore = mockk<FirebaseFirestore>()
+        val collection = mockk<CollectionReference>()
+        val query = mockk<Query>()
+        val snapshot = mockk<QuerySnapshot>()
+
+        every { firestore.collection("activities") } returns collection
+        every { collection.orderBy(any<String>(), any()) } returns query
+        every { query.limit(any()) } returns query
+        every { query.get() } returns Tasks.forResult(snapshot)
+        every { snapshot.documents } returns documents.toList()
+
+        val network = ConnectedNetworkManager()
+
+        val factory = object : androidx.work.WorkerFactory() {
+            override fun createWorker(
+                appContext: Context,
+                workerClassName: String,
+                workerParameters: WorkerParameters
+            ): ListenableWorker {
+                return SyncWorker(appContext, workerParameters, db, firestore, network)
+            }
+        }
+
+        return TestListenableWorkerBuilder<SyncWorker>(context)
+            .setWorkerFactory(factory)
+            .build()
+    }
+
+    private fun createDocument(id: String, data: Map<String, Any?>?): DocumentSnapshot {
+        val doc = mockk<DocumentSnapshot>()
+        every { doc.id } returns id
+        every { doc.data } returns data
+        return doc
+    }
+
+    @Test
+    fun insertsDocumentUsingDocumentIdWhenDataIdMissing() = runTest {
+        val doc = createDocument(
+            id = "firebase123",
+            data = mapOf(
+                "name" to "Test",
+                "type" to "Type",
+                "energy" to 5,
+                "people" to "",
+                "mood" to "",
+                "notes" to "",
+                "date" to 1L,
+                "duration" to 10L,
+                "socialInteractionLevel" to 1,
+                "stressLevel" to 2,
+                "isManualEntry" to true,
+                "lastModified" to 1L
+            )
+        )
+
+        val worker = buildWorker(doc)
+        val result = worker.doWork()
+        assertTrue(result is ListenableWorker.Result.Success)
+
+        val activities = db.activityDao().getAllActivitiesForBackup()
+        assertEquals(1, activities.size)
+        assertEquals("firebase123", activities[0].firebaseId)
+    }
+
+    @Test
+    fun skipsDocumentWhenIdMissing() = runTest {
+        val doc = createDocument(
+            id = "",
+            data = mapOf(
+                "name" to "Test",
+                "type" to "Type",
+                "energy" to 5,
+                "people" to "",
+                "mood" to "",
+                "notes" to "",
+                "date" to 1L,
+                "duration" to 10L,
+                "socialInteractionLevel" to 1,
+                "stressLevel" to 2,
+                "isManualEntry" to true,
+                "lastModified" to 1L
+            )
+        )
+
+        val worker = buildWorker(doc)
+        val result = worker.doWork()
+        assertTrue(result is ListenableWorker.Result.Success)
+
+        val activities = db.activityDao().getAllActivitiesForBackup()
+        assertTrue(activities.isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary
- add Room query to fetch activity by firebaseId
- use Firestore document ids during sync, wrap downloads in Room transaction and log malformed documents
- add unit tests covering documents with and without ids

## Testing
- `./gradlew :app:test` *(fails: Invalid catalog definition in version catalog `libs`)*

------
https://chatgpt.com/codex/tasks/task_e_6894d67f8de88324b937bfa36c6db0ea