### PR TITLE
Inject FirebaseAuth through Hilt and add tests

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/features/auth/data/AuthModule.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/auth/data/AuthModule.kt
@@ -1,0 +1,17 @@
+package com.example.socialbatterymanager.features.auth.data
+
+import com.google.firebase.auth.FirebaseAuth
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class AuthModule {
+
+    @Provides
+    @Singleton
+    fun provideFirebaseAuth(): FirebaseAuth = FirebaseAuth.getInstance()
+}

--- a/app/src/main/java/com/example/socialbatterymanager/features/auth/data/AuthRepository.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/auth/data/AuthRepository.kt
@@ -9,9 +9,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class AuthRepository @Inject constructor() {
-    
-    private val auth: FirebaseAuth = FirebaseAuth.getInstance()
+class AuthRepository @Inject constructor(private val auth: FirebaseAuth) {
     
     val currentUser: FirebaseUser?
         get() = auth.currentUser

--- a/app/src/main/java/com/example/socialbatterymanager/features/auth/ui/UserViewModel.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/auth/ui/UserViewModel.kt
@@ -11,7 +11,9 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class UserViewModel @Inject constructor(private val authRepository: AuthRepository) : ViewModel() {
+class UserViewModel @Inject constructor(
+    private val authRepository: AuthRepository
+) : ViewModel() {
     
     private val _user = MutableLiveData<FirebaseUser?>()
     val user: LiveData<FirebaseUser?> = _user

--- a/app/src/main/java/com/example/socialbatterymanager/features/privacy/ui/PrivacySettingsFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/privacy/ui/PrivacySettingsFragment.kt
@@ -30,9 +30,12 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.launch
 import androidx.appcompat.widget.SwitchCompat
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 private val Context.privacyDataStore by preferencesDataStore(name = "privacy_preferences")
 
+@AndroidEntryPoint
 class PrivacySettingsFragment : Fragment() {
 
     // UI Components
@@ -51,7 +54,7 @@ class PrivacySettingsFragment : Fragment() {
     private var currentPrivacySettings: UserPrivacySettings? = null
     private val blockedUsers = mutableListOf<BlockedUser>()
     private lateinit var blockedUsersAdapter: BlockedUsersAdapter
-    private val authRepository = AuthRepository()
+    @Inject lateinit var authRepository: AuthRepository
     private val gson = Gson()
 
     // DataStore keys

--- a/app/src/test/java/com/example/socialbatterymanager/auth/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/auth/AuthRepositoryTest.kt
@@ -1,21 +1,31 @@
 package com.example.socialbatterymanager.auth
 
+import com.example.socialbatterymanager.features.auth.data.AuthRepository
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlin.test.assertEquals
 import org.junit.Test
-import org.junit.Assert.*
 
 class AuthRepositoryTest {
-    
+
+    private val firebaseAuth: FirebaseAuth = mockk(relaxed = true)
+    private val authRepository = AuthRepository(firebaseAuth)
+
     @Test
-    fun `test AuthRepository initialization`() {
-        val authRepository = AuthRepository()
-        assertNotNull(authRepository)
+    fun `currentUser returns value from FirebaseAuth`() {
+        val user: FirebaseUser = mockk()
+        every { firebaseAuth.currentUser } returns user
+
+        assertEquals(user, authRepository.currentUser)
     }
-    
+
     @Test
-    fun `test initial user state`() {
-        val authRepository = AuthRepository()
-        // User should not be logged in initially without Firebase setup
-        // This is a basic test to ensure the class structure works
-        assertTrue(authRepository.currentUser == null)
+    fun `signOut delegates to FirebaseAuth`() {
+        authRepository.signOut()
+
+        verify { firebaseAuth.signOut() }
     }
 }


### PR DESCRIPTION
## Summary
- Inject FirebaseAuth into AuthRepository and expose it via new Hilt AuthModule
- Use Hilt to supply AuthRepository in PrivacySettingsFragment and format UserViewModel
- Add unit tests with a mocked FirebaseAuth

## Testing
- `./gradlew test` *(fails: Invalid catalog definition; version catalog libs 'from' method called more than once)*

------
https://chatgpt.com/codex/tasks/task_e_6894d68009d48324a4cc574b933d6fbb