### PR TITLE
Add transactional restore with logging and tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -118,6 +118,7 @@ dependencies {
     testImplementation(libs.findLibrary("kotlinx-coroutines-test").get())
     testImplementation(libs.findLibrary("mockk").get())
     testImplementation(libs.findLibrary("robolectric").get())
+    testImplementation(mainLibs.findLibrary("androidx-test-core").get())
     androidTestImplementation(libs.findLibrary("androidx-test-junit").get())
     androidTestImplementation(libs.findLibrary("androidx-test-espresso").get())
     androidTestImplementation(platform(libs.findLibrary("compose-bom").get()))

--- a/app/src/main/java/com/example/socialbatterymanager/data/database/ActivityDao.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/data/database/ActivityDao.kt
@@ -58,4 +58,7 @@ interface ActivityDao {
 
     @Query("SELECT COALESCE(SUM(ABS(energy)), 0) FROM activities WHERE date >= :fromDate AND isDeleted = 0")
     suspend fun getTotalEnergyUsedFromDate(fromDate: Long): Int
+
+    @Query("DELETE FROM activities")
+    suspend fun deleteAllActivities()
 }

--- a/app/src/main/java/com/example/socialbatterymanager/data/database/AuditLogDao.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/data/database/AuditLogDao.kt
@@ -22,7 +22,10 @@ interface AuditLogDao {
     
     @Query("DELETE FROM audit_logs WHERE timestamp < :cutoff")
     suspend fun deleteAuditLogsOlderThan(cutoff: Long)
-    
+
     @Query("SELECT COUNT(*) FROM audit_logs")
     suspend fun getAuditLogCount(): Int
+
+    @Query("DELETE FROM audit_logs")
+    suspend fun deleteAllAuditLogs()
 }

--- a/app/src/main/java/com/example/socialbatterymanager/data/repository/ActivityRepository.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/data/repository/ActivityRepository.kt
@@ -66,5 +66,9 @@ class ActivityRepository(
     suspend fun hardDeleteOldActivities(cutoff: Long) {
         activityDao.hardDeleteOldActivities(cutoff)
     }
+
+    suspend fun clearAllActivities() {
+        activityDao.deleteAllActivities()
+    }
 }
 

--- a/app/src/main/java/com/example/socialbatterymanager/data/repository/AuditRepository.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/data/repository/AuditRepository.kt
@@ -42,5 +42,9 @@ class AuditRepository(
     suspend fun insertAuditLogRaw(auditLog: AuditLogEntity) {
         auditLogDao.insertAuditLog(auditLog)
     }
+
+    suspend fun clearAuditLogs() {
+        auditLogDao.deleteAllAuditLogs()
+    }
 }
 

--- a/app/src/test/java/com/example/socialbatterymanager/data/repository/BackupManagerRestoreTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/data/repository/BackupManagerRestoreTest.kt
@@ -1,0 +1,106 @@
+package com.example.socialbatterymanager.data.repository
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.example.socialbatterymanager.data.database.AppDatabase
+import com.example.socialbatterymanager.data.model.ActivityEntity
+import com.example.socialbatterymanager.data.model.AuditLogEntity
+import com.example.socialbatterymanager.data.model.BackupData
+import com.example.socialbatterymanager.shared.preferences.PreferencesManager
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.gson.Gson
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.any
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+class BackupManagerRestoreTest {
+    private lateinit var context: Context
+    private lateinit var db: AppDatabase
+    private lateinit var activityRepo: ActivityRepository
+    private lateinit var auditRepo: AuditRepository
+    private lateinit var backupRepo: BackupRepository
+    private lateinit var crashlytics: FirebaseCrashlytics
+    private lateinit var backupManager: BackupManager
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        val gson = Gson()
+        auditRepo = AuditRepository(db.auditLogDao(), gson)
+        activityRepo = ActivityRepository(db.activityDao(), auditRepo)
+        backupRepo = BackupRepository(db.activityDao(), db.auditLogDao(), db.backupMetadataDao(), gson)
+        val prefs = mockk<PreferencesManager>(relaxed = true)
+        val firestore = mockk<FirebaseFirestore>(relaxed = true)
+        crashlytics = mockk(relaxed = true)
+        backupManager = BackupManager(
+            context,
+            activityRepo,
+            auditRepo,
+            backupRepo,
+            prefs,
+            db,
+            firestore,
+            gson,
+            crashlytics
+        )
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun restoreFromLocalBackup_success() = runBlocking {
+        activityRepo.insertActivityRaw(
+            ActivityEntity(name = "old", type = "t", energy = 1, people = "p", mood = "m", notes = "n", date = 0)
+        )
+        auditRepo.insertAuditLogRaw(
+            AuditLogEntity(entityType = "activity", entityId = "1", action = "create")
+        )
+
+        val newActivity = ActivityEntity(id = 2, name = "new", type = "t", energy = 2, people = "p", mood = "m", notes = "n", date = 1)
+        val newAudit = AuditLogEntity(entityType = "activity", entityId = "2", action = "create")
+        val backupData = BackupData(1, 0L, listOf(newActivity), listOf(newAudit), "chk")
+        val backupId = "test"
+        val file = File(context.getExternalFilesDir(null), "backup_${backupId}.json")
+        file.writeText(Gson().toJson(backupData))
+
+        val result = backupManager.restoreFromLocalBackup(backupId)
+        assertTrue(result)
+        val activities = activityRepo.getAllActivities().first()
+        assertEquals(1, activities.size)
+        assertEquals("new", activities[0].name)
+        val logs = auditRepo.getAllAuditLogs().first()
+        assertEquals(1, logs.size)
+        assertEquals("2", logs[0].entityId)
+    }
+
+    @Test
+    fun restoreFromLocalBackup_failure_logsException() = runBlocking {
+        val backupId = "bad"
+        val file = File(context.getExternalFilesDir(null), "backup_${backupId}.json")
+        file.writeText("{ bad json")
+
+        val result = backupManager.restoreFromLocalBackup(backupId)
+        assertFalse(result)
+        verify { crashlytics.recordException(any()) }
+    }
+}

--- a/app/src/test/java/com/example/socialbatterymanager/data/repository/DataRepositoryAuditBackupTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/data/repository/DataRepositoryAuditBackupTest.kt
@@ -43,6 +43,7 @@ private class FakeActivityDao : ActivityDao {
     override suspend fun getActivitiesByDateRangeSync(start: Long, end: Long): List<ActivityEntity> = emptyList()
     override suspend fun getActivitiesCountFromDate(fromDate: Long): Int = 0
     override suspend fun getTotalEnergyUsedFromDate(fromDate: Long): Int = 0
+    override suspend fun deleteAllActivities() { activities.clear() }
 }
 
 private class FakeAuditLogDao : AuditLogDao {
@@ -59,6 +60,7 @@ private class FakeAuditLogDao : AuditLogDao {
         logs.value = logs.value.filter { it.timestamp >= cutoff }
     }
     override suspend fun getAuditLogCount(): Int = logs.value.size
+    override suspend fun deleteAllAuditLogs() { logs.value = emptyList() }
 }
 
 private class FakeBackupMetadataDao : BackupMetadataDao {

--- a/app/src/test/java/com/example/socialbatterymanager/features/home/HomeRepositoryTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/features/home/HomeRepositoryTest.kt
@@ -30,6 +30,7 @@ private class FakeActivityDao(private val count: Int) : ActivityDao {
     override suspend fun incrementUsageCount(id: Int) = throw NotImplementedError()
     override suspend fun getActivitiesByDateRangeSync(start: Long, end: Long): List<ActivityEntity> = throw NotImplementedError()
     override suspend fun getTotalEnergyUsedFromDate(fromDate: Long): Int = throw NotImplementedError()
+    override suspend fun deleteAllActivities() = throw NotImplementedError()
 }
 
 private class FakeAppDatabase(private val activityDao: ActivityDao) : AppDatabase() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ mockk = "1.14.5"
 robolectric = "4.15.1"
 androidx-test-junit = "1.3.0"
 androidx-test-espresso = "3.7.0"
+androidx-test-core = "1.6.1"
 compose-bom = "2024.09.00"
 work-testing = "2.10.3"
 fragment-testing = "1.8.8"
@@ -80,6 +81,7 @@ mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 androidx-test-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-junit" }
 androidx-test-espresso = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidx-test-espresso" }
+androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidx-test-core" }
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
 work-testing = { group = "androidx.work", name = "work-testing", version.ref = "work-testing" }
 fragment-testing = { group = "androidx.fragment", name = "fragment-testing", version.ref = "fragment-testing" }


### PR DESCRIPTION
## Summary
- Wrap backup restore operations in a Room transaction
- Clear existing activities and audit logs before inserting restored data
- Log restore and backup failures to Firebase Crashlytics and add restore tests

## Testing
- `./gradlew :app:test` *(fails: In version catalog libs, you can only call the 'from' method a single time)*

------
https://chatgpt.com/codex/tasks/task_e_6894d68405b88324b24125fccb23ae65