### PR TITLE
Add person query for activities and optimize stats calculator

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/data/database/ActivityDao.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/data/database/ActivityDao.kt
@@ -22,6 +22,11 @@ interface ActivityDao {
     
     @Query("SELECT * FROM activities WHERE id = :id AND isDeleted = 0")
     suspend fun getActivityById(id: Int): ActivityEntity?
+
+    @Query(
+        "SELECT * FROM activities WHERE isDeleted = 0 AND LOWER(people) LIKE '%' || LOWER(:personName) || '%' ORDER BY date DESC"
+    )
+    suspend fun getActivitiesByPersonName(personName: String): List<ActivityEntity>
     
     @Query("UPDATE activities SET isDeleted = 1, updatedAt = :timestamp WHERE id = :id")
     suspend fun softDeleteActivity(id: Int, timestamp: Long = System.currentTimeMillis())

--- a/app/src/main/java/com/example/socialbatterymanager/features/people/data/PersonStatsCalculator.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/features/people/data/PersonStatsCalculator.kt
@@ -3,7 +3,6 @@ package com.example.socialbatterymanager.features.people.data
 import android.content.Context
 import com.example.socialbatterymanager.data.database.AppDatabase
 import com.example.socialbatterymanager.data.model.Person
-import kotlinx.coroutines.flow.first
 
 data class PersonStats(
     val person: Person,
@@ -18,12 +17,7 @@ class PersonStatsCalculator(private val context: Context) {
     
     suspend fun calculateStats(person: Person): PersonStats {
         val db = AppDatabase.getDatabase(context)
-        val activities = db.activityDao().getAllActivities().first()
-        
-        // Filter activities that mention this person
-        val personActivities = activities.filter { activity ->
-            activity.people.contains(person.name, ignoreCase = true)
-        }
+        val personActivities = db.activityDao().getActivitiesByPersonName(person.name)
         
         val totalActivities = personActivities.size
         val averageEnergyImpact: Double = if (personActivities.isNotEmpty()) {

--- a/app/src/test/java/com/example/socialbatterymanager/data/repository/DataRepositoryAuditBackupTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/data/repository/DataRepositoryAuditBackupTest.kt
@@ -25,6 +25,8 @@ private class FakeActivityDao : ActivityDao {
     }
     override fun getAllActivities(): Flow<List<ActivityEntity>> = MutableStateFlow(activities.toList())
     override suspend fun getActivityById(id: Int): ActivityEntity? = activities.find { it.id == id }
+    override suspend fun getActivitiesByPersonName(personName: String): List<ActivityEntity> =
+        activities.filter { it.people.contains(personName) }
     override suspend fun softDeleteActivity(id: Int, timestamp: Long) {
         val index = activities.indexOfFirst { it.id == id }
         if (index >= 0) {

--- a/app/src/test/java/com/example/socialbatterymanager/features/home/HomeRepositoryTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/features/home/HomeRepositoryTest.kt
@@ -19,6 +19,7 @@ private class FakeActivityDao(private val count: Int) : ActivityDao {
     override suspend fun updateActivity(activity: ActivityEntity) = throw NotImplementedError()
     override fun getAllActivities(): Flow<List<ActivityEntity>> = throw NotImplementedError()
     override suspend fun getActivityById(id: Int): ActivityEntity? = throw NotImplementedError()
+    override suspend fun getActivitiesByPersonName(personName: String): List<ActivityEntity> = throw NotImplementedError()
     override suspend fun softDeleteActivity(id: Int, timestamp: Long) = throw NotImplementedError()
     override suspend fun deleteActivity(activity: ActivityEntity) = throw NotImplementedError()
     override suspend fun getAllActivitiesForBackup(): List<ActivityEntity> = throw NotImplementedError()

--- a/app/src/test/java/com/example/socialbatterymanager/features/people/ActivityDaoMemoryTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/features/people/ActivityDaoMemoryTest.kt
@@ -1,0 +1,61 @@
+package com.example.socialbatterymanager.features.people
+
+import android.content.Context
+import androidx.room.Room
+import com.example.socialbatterymanager.data.database.AppDatabase
+import com.example.socialbatterymanager.data.model.ActivityEntity
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class ActivityDaoMemoryTest {
+    @Test
+    fun filteredQuery_usesLessMemoryThanFetchingAll() = runBlocking {
+        val context: Context = RuntimeEnvironment.getApplication()
+        val db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        val dao = db.activityDao()
+        val targetName = "Alice"
+
+        repeat(10000) { index ->
+            val people = if (index % 200 == 0) "$targetName,Bob" else "Bob,Charlie"
+            dao.insertActivity(
+                ActivityEntity(
+                    name = "Activity $index",
+                    type = "Social",
+                    energy = index % 5,
+                    people = people,
+                    mood = "Happy",
+                    notes = "",
+                    date = index.toLong()
+                )
+            )
+        }
+
+        val runtime = Runtime.getRuntime()
+        System.gc()
+        var before = runtime.totalMemory() - runtime.freeMemory()
+        var allActivities: List<ActivityEntity>? = dao.getAllActivities().first()
+        var after = runtime.totalMemory() - runtime.freeMemory()
+        val memoryAll = after - before
+        val expectedCount = allActivities!!.count { it.people.contains(targetName) }
+        allActivities = null
+        System.gc()
+
+        before = runtime.totalMemory() - runtime.freeMemory()
+        val filtered = dao.getActivitiesByPersonName(targetName)
+        after = runtime.totalMemory() - runtime.freeMemory()
+        val memoryFiltered = after - before
+
+        assertEquals(expectedCount, filtered.size)
+        assertTrue(memoryFiltered < memoryAll)
+        db.close()
+    }
+}


### PR DESCRIPTION
## Summary
- add a DAO query to fetch activities mentioning a given person
- streamline `PersonStatsCalculator` to query the DB directly
- add a unit test comparing memory usage of filtered query vs full fetch

## Testing
- `./gradlew :app:test --stacktrace` *(fails: Invalid catalog definition - Problem: In version catalog libs, you can only call the 'from' method a single time)*

------
https://chatgpt.com/codex/tasks/task_e_6894d6807268832485215e1529be69eb