### PR TITLE
Secure database passphrase handling

### DIFF
--- a/app/src/test/java/com/example/socialbatterymanager/data/repository/SecurityManagerTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/data/repository/SecurityManagerTest.kt
@@ -1,5 +1,6 @@
 package com.example.socialbatterymanager.data.repository
 
+import android.content.SharedPreferences
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.*
 import org.junit.Test
@@ -20,6 +21,12 @@ class SecurityManagerTest {
         val passphrase = manager.generateDatabasePassphrase()
         val retrieved = manager.getDatabasePassphrase()
         assertEquals(passphrase, retrieved)
+
+        val field = SecurityManager::class.java.getDeclaredField("encryptedPrefs")
+        field.isAccessible = true
+        val prefs = field.get(manager) as SharedPreferences
+        val stored = prefs.getString("db_passphrase", null)
+        assertNotEquals(passphrase, stored)
 
         val prefsFile = File(context.filesDir.parent + "/shared_prefs/encrypted_prefs.xml")
         val content = prefsFile.readText()


### PR DESCRIPTION
## Summary
- Generate a random database passphrase and encrypt it with an AES/GCM Keystore key
- Store encrypted passphrase in EncryptedSharedPreferences and decrypt on retrieval
- Extend tests to verify passphrase isn't stored in plaintext

## Testing
- `./gradlew test` *(fails: Invalid catalog definition - 'from' method called more than once)*

------
https://chatgpt.com/codex/tasks/task_e_6894dd493e148324b41a2ffd5b6b78c5