### PR TITLE
Improve energy reminder notifications

### DIFF
--- a/NOTIFICATION_STRATEGY.md
+++ b/NOTIFICATION_STRATEGY.md
@@ -1,0 +1,12 @@
+# Notification Strategy
+
+The app alerts users when their social battery drops below a configured threshold. These notifications are dispatched by
+`EnergyReminderWorker` and follow these guidelines:
+
+- **Channel**: Notifications are posted to the `social_battery_reminders` channel.
+- **Unique IDs**: Each reminder uses a unique ID derived from `System.currentTimeMillis()` so multiple alerts don't overwrite
+  one another.
+- **App Launch**: Tapping a notification opens `MainActivity` via a `PendingIntent`, ensuring users land inside the app.
+- **Auto-cancel**: Notifications dismiss themselves when tapped to avoid clutter.
+
+Maintain this strategy when introducing new notifications to keep a consistent user experience.

--- a/app/src/main/java/com/example/socialbatterymanager/notification/EnergyReminderWorker.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/notification/EnergyReminderWorker.kt
@@ -3,12 +3,15 @@ package com.example.socialbatterymanager.notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
+import android.app.PendingIntent
+import android.content.Intent
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.example.socialbatterymanager.R
+import com.example.socialbatterymanager.MainActivity
 import com.example.socialbatterymanager.data.database.AppDatabase
 import com.example.socialbatterymanager.shared.preferences.PreferencesManager
 import dagger.assisted.Assisted
@@ -48,18 +51,30 @@ class EnergyReminderWorker @AssistedInject constructor(
     private fun showNotification(title: String, message: String) {
         createNotificationChannel()
 
+        val intent = Intent(appContext, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            appContext,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
         val notification = NotificationCompat.Builder(appContext, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_launcher_foreground)
             .setContentTitle(title)
             .setContentText(message)
             .setStyle(NotificationCompat.BigTextStyle().bigText(message))
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setContentIntent(pendingIntent)
             .setAutoCancel(true)
             .build()
 
         val notificationManager =
             appContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.notify(NOTIFICATION_ID, notification)
+        val notificationId = System.currentTimeMillis().toInt()
+        notificationManager.notify(notificationId, notification)
     }
 
     private fun createNotificationChannel() {
@@ -80,7 +95,6 @@ class EnergyReminderWorker @AssistedInject constructor(
 
     companion object {
         const val CHANNEL_ID = "social_battery_reminders"
-        const val NOTIFICATION_ID = 1
     }
 }
 


### PR DESCRIPTION
## Summary
- Generate a unique notification ID using `System.currentTimeMillis()`
- Launch the app when tapping energy reminder notifications
- Document notification strategy for future maintainers

## Testing
- `./gradlew test` *(fails: In version catalog libs, you can only call the 'from' method a single time)*

------
https://chatgpt.com/codex/tasks/task_e_6894dd5fe94083249735d872d108a0ba