### PR TITLE
Use CSV library for exports and add quoting tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -112,6 +112,7 @@ dependencies {
     implementation(mainLibs.findLibrary("firebase-auth-ktx").get())
     implementation(mainLibs.findLibrary("firebase-crashlytics-ktx").get())
     implementation(mainLibs.findLibrary("pdfbox").get())
+    implementation(mainLibs.findLibrary("opencsv").get())
     debugImplementation(mainLibs.findLibrary("fragment-testing").get())
 
     // Test dependencies

--- a/app/src/main/java/com/example/socialbatterymanager/data/repository/ImportExportManager.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/data/repository/ImportExportManager.kt
@@ -2,8 +2,8 @@ package com.example.socialbatterymanager.data.repository
 
 import android.content.Context
 import com.example.socialbatterymanager.data.model.ActivityEntity
-import com.opencsv.CSVReader
-import com.opencsv.CSVWriter
+import com.opencsv.CSVReaderBuilder
+import com.opencsv.CSVWriterBuilder
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -34,7 +34,7 @@ class ImportExportManager @Inject constructor(
             val fileName = "social_battery_export_${System.currentTimeMillis()}.csv"
             val file = File(context.getExternalFilesDir(null), fileName)
 
-            CSVWriter(FileWriter(file)).use { writer ->
+            CSVWriterBuilder(FileWriter(file)).build().use { writer ->
                 writer.writeNext(
                     arrayOf(
                         "ID", "Name", "Type", "Energy", "People",
@@ -162,7 +162,7 @@ class ImportExportManager @Inject constructor(
             var errorCount = 0
 
             file.bufferedReader().use { reader ->
-                CSVReader(reader).use { csvReader ->
+                CSVReaderBuilder(reader).build().use { csvReader ->
                     val headers = csvReader.readNext()?.map { it.trim() }
                     if (headers == null || headers.size < 7) {
                         return ImportResult(0, 0, "Invalid or missing headers")

--- a/app/src/main/java/com/example/socialbatterymanager/reports/ReportsFragment.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/reports/ReportsFragment.kt
@@ -23,6 +23,7 @@ import com.github.mikephil.charting.charts.BarChart
 import com.github.mikephil.charting.data.*
 import com.github.mikephil.charting.formatter.IndexAxisValueFormatter
 import com.github.mikephil.charting.utils.ColorTemplate
+import com.opencsv.CSVWriter
 import java.io.File
 import java.io.FileWriter
 import java.text.SimpleDateFormat
@@ -362,19 +363,25 @@ class ReportsFragment : Fragment() {
         viewModel.getActivitiesForPeriod(dateRange.first, dateRange.second) { activities ->
             try {
                 val file = File(requireContext().getExternalFilesDir(null), "social_battery_report.csv")
-                val writer = FileWriter(file)
-
-                // Write CSV header
-                writer.append("Date,Activity,Type,Energy,Mood,People,Notes\n")
-
-                // Write data
                 val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
-                activities.forEach { activity ->
-                    val date = dateFormat.format(Date(activity.date))
-                    writer.append("$date,${activity.name},${activity.type},${activity.energy},${activity.mood},${activity.people},${activity.notes}\n")
-                }
 
-                writer.close()
+                CSVWriter(FileWriter(file)).use { writer ->
+                    writer.writeNext(arrayOf("Date", "Activity", "Type", "Energy", "Mood", "People", "Notes"))
+                    activities.forEach { activity ->
+                        val date = dateFormat.format(Date(activity.date))
+                        writer.writeNext(
+                            arrayOf(
+                                date,
+                                activity.name,
+                                activity.type,
+                                activity.energy.toString(),
+                                activity.mood,
+                                activity.people,
+                                activity.notes
+                            )
+                        )
+                    }
+                }
 
                 // Share file
                 val uri = FileProvider.getUriForFile(

--- a/app/src/test/java/com/example/socialbatterymanager/data/repository/ImportExportManagerTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/data/repository/ImportExportManagerTest.kt
@@ -5,14 +5,21 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.socialbatterymanager.data.model.ActivityEntity
 import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.slot
 import io.mockk.mockk
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
+import com.opencsv.CSVReader
+import com.opencsv.CSVWriter
 import org.apache.pdfbox.pdmodel.PDDocument
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileWriter
 
 @RunWith(AndroidJUnit4::class)
 class ImportExportManagerTest {
@@ -46,5 +53,77 @@ class ImportExportManagerTest {
             assertTrue(doc.numberOfPages > 1)
         }
         file?.delete()
+    }
+
+    @Test
+    fun exportToCsv_handlesSpecialCharacters() = runBlocking {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        val now = System.currentTimeMillis()
+        val activities = listOf(
+            ActivityEntity(
+                id = 1,
+                name = "Meeting, with team",
+                type = "Work",
+                energy = 5,
+                people = "Alice, Bob",
+                mood = "Happy \"Excited\"",
+                notes = "Line1\nLine2",
+                date = now,
+                lastModified = now,
+                updatedAt = now
+            )
+        )
+
+        val repository = mockk<ActivityRepository>()
+        coEvery { repository.getAllActivities() } returns flowOf(activities)
+
+        val manager = ImportExportManager(context, repository)
+        val file = manager.exportToCsv()
+
+        assertNotNull(file)
+        CSVReader(file!!.reader()).use { reader ->
+            val rows = reader.readAll()
+            assertEquals(2, rows.size)
+            val row = rows[1]
+            assertEquals("Meeting, with team", row[1])
+            assertEquals("Alice, Bob", row[4])
+            assertEquals("Happy \"Excited\"", row[5])
+            assertEquals("Line1\nLine2", row[6])
+        }
+        file.delete()
+    }
+
+    @Test
+    fun importFromCsv_handlesSpecialCharacters() = runBlocking {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        val repository = mockk<ActivityRepository>()
+        coEvery { repository.insertActivity(any(), any()) } returns Unit
+
+        val manager = ImportExportManager(context, repository)
+        val file = File(context.getExternalFilesDir(null), "import_test.csv")
+        CSVWriter(FileWriter(file)).use { writer ->
+            writer.writeNext(arrayOf("ID", "Name", "Type", "Energy", "People", "Mood", "Notes"))
+            writer.writeNext(
+                arrayOf(
+                    "1",
+                    "Meeting, with team",
+                    "Work",
+                    "5",
+                    "Alice, Bob",
+                    "Happy \"Excited\"",
+                    "Line1\nLine2"
+                )
+            )
+        }
+
+        val result = manager.importFromCsv(file)
+        assertEquals(1, result.successCount)
+        val slot = slot<ActivityEntity>()
+        coVerify { repository.insertActivity(capture(slot), "import") }
+        assertEquals("Meeting, with team", slot.captured.name)
+        assertEquals("Alice, Bob", slot.captured.people)
+        assertEquals("Happy \"Excited\"", slot.captured.mood)
+        assertEquals("Line1\nLine2", slot.captured.notes)
+        file.delete()
     }
 }


### PR DESCRIPTION
## Summary
- replace manual CSV concatenation with OpenCSV in reports export
- ensure repository import/export use OpenCSV builders for proper quoting
- add tests for CSV handling of commas, quotes, and newlines

## Testing
- `./gradlew :app:test` *(fails: Invalid catalog definition: In version catalog libs, you can only call the 'from' method a single time)*

------
https://chatgpt.com/codex/tasks/task_e_6894dd5b37ac83248d57174114960965