### PR TITLE
Add coverage-enforced tests for key managers

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Install SDK components
         run: sdkmanager --install "platform-tools" "platforms;android-30" "build-tools;30.0.3" "platforms;android-35" "build-tools;35.0.0"
 
-      - name: Run JVM unit tests
-        run: ./gradlew test
+      - name: Run JVM unit tests with coverage
+        run: ./gradlew jacocoTestCoverageVerification
 
       - name: Assemble debug APK
         run: ./gradlew assembleDebug

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.testing.jacoco.tasks.JacocoCoverageVerification
+import org.gradle.testing.jacoco.tasks.JacocoReport
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android") version "2.2.0"
@@ -9,6 +12,7 @@ plugins {
     id("com.google.dagger.hilt.android")
     id("org.jetbrains.kotlin.plugin.compose")
     id("com.google.devtools.ksp") version libs.versions.ksp.get()
+    jacoco
 }
 
 // Ensure the version catalog is properly imported
@@ -122,9 +126,11 @@ dependencies {
     testImplementation(libs.findLibrary("robolectric").get())
     testImplementation(libs.findLibrary("work-testing").get())
     androidTestImplementation(libs.findLibrary("androidx-test-junit").get())
+    androidTestImplementation(libs.findLibrary("androidx-test-core").get())
     androidTestImplementation(libs.findLibrary("androidx-test-espresso").get())
     androidTestImplementation(platform(libs.findLibrary("compose-bom").get()))
     androidTestImplementation(libs.findLibrary("work-testing").get())
+    androidTestImplementation(libs.findLibrary("mockk-android").get())
     debugImplementation(libs.findLibrary("fragment-testing").get())
     debugImplementation(libs.findLibrary("ui-tooling").get())
     debugImplementation(libs.findLibrary("ui-test-manifest").get())
@@ -159,4 +165,45 @@ detekt {
 
 kotlin {
     jvmToolchain(17)
+}
+
+jacoco {
+    toolVersion = "0.8.11"
+}
+
+tasks.withType<Test> {
+    finalizedBy("jacocoTestReport")
+}
+
+tasks.register<JacocoReport>("jacocoTestReport") {
+    dependsOn("testDebugUnitTest")
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+    classDirectories.setFrom(
+        fileTree("${'$'}{buildDir}/tmp/kotlin-classes/debug") {
+            exclude("**/R.class", "**/R${'$'}*.class", "**/BuildConfig.*", "**/Manifest*.*", "**/*Test*.*")
+        },
+    )
+    sourceDirectories.setFrom(files("src/main/java"))
+    executionData.setFrom(fileTree(buildDir) { include("**/jacoco/testDebugUnitTest.exec") })
+}
+
+tasks.register<JacocoCoverageVerification>("jacocoTestCoverageVerification") {
+    dependsOn("jacocoTestReport")
+    classDirectories.setFrom(
+        fileTree("${'$'}{buildDir}/tmp/kotlin-classes/debug") {
+            exclude("**/R.class", "**/R${'$'}*.class", "**/BuildConfig.*", "**/Manifest*.*", "**/*Test*.*")
+        },
+    )
+    sourceDirectories.setFrom(files("src/main/java"))
+    executionData.setFrom(fileTree(buildDir) { include("**/jacoco/testDebugUnitTest.exec") })
+    violationRules {
+        rule {
+            limit {
+                minimum = "0.5".toBigDecimal()
+            }
+        }
+    }
 }

--- a/app/src/androidTest/java/com/example/socialbatterymanager/data/repository/ActivityRepositoryInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/example/socialbatterymanager/data/repository/ActivityRepositoryInstrumentedTest.kt
@@ -1,0 +1,39 @@
+package com.example.socialbatterymanager.data.repository
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.socialbatterymanager.data.database.ActivityDao
+import com.example.socialbatterymanager.data.model.ActivityEntity
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ActivityRepositoryInstrumentedTest {
+
+    private val dao = mockk<ActivityDao>(relaxed = true)
+    private val auditRepo = mockk<AuditRepository>(relaxed = true)
+    private val repository = ActivityRepository(dao, auditRepo)
+
+    @Test
+    fun markAsUsed_incrementsUsageCount() = runBlocking {
+        val entity = ActivityEntity(
+            id = 3,
+            name = "Test",
+            type = "Type",
+            energy = 1,
+            people = "Solo",
+            mood = "Ok",
+            notes = "",
+            date = 0L,
+        )
+        coEvery { dao.getActivityById(entity.id) } returns entity
+
+        repository.markAsUsed(entity.id)
+
+        coVerify { dao.incrementUsageCount(entity.id) }
+    }
+}
+

--- a/app/src/androidTest/java/com/example/socialbatterymanager/shared/preferences/PreferencesManagerInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/example/socialbatterymanager/shared/preferences/PreferencesManagerInstrumentedTest.kt
@@ -1,0 +1,35 @@
+package com.example.socialbatterymanager.shared.preferences
+
+import android.content.Context
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class PreferencesManagerInstrumentedTest {
+
+    @Test
+    fun setTheme_persistsValue() = runBlocking {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        val file = File(context.filesDir, "prefs_test.preferences_pb").apply { delete() }
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = CoroutineScope(Dispatchers.IO),
+            produceFile = { file },
+        )
+        val manager = PreferencesManager(dataStore)
+
+        manager.setTheme(PreferencesManager.THEME_DARK)
+
+        assertEquals(PreferencesManager.THEME_DARK, manager.themeFlow.first())
+        file.delete()
+    }
+}
+

--- a/app/src/androidTest/java/com/example/socialbatterymanager/sync/SyncManagerInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/example/socialbatterymanager/sync/SyncManagerInstrumentedTest.kt
@@ -1,0 +1,29 @@
+package com.example.socialbatterymanager.sync
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.WorkManager
+import com.example.socialbatterymanager.shared.preferences.PreferencesManager
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SyncManagerInstrumentedTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val workManager = mockk<WorkManager>(relaxed = true)
+    private val prefs = mockk<PreferencesManager>(relaxed = true)
+
+    @Test
+    fun forceSyncNow_enqueuesWork() {
+        val manager = SyncManager(context, workManager, prefs)
+
+        manager.forceSyncNow()
+
+        verify { workManager.enqueue(any()) }
+    }
+}
+

--- a/app/src/main/java/com/example/socialbatterymanager/sync/SyncManager.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/sync/SyncManager.kt
@@ -8,18 +8,19 @@ import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
-import com.google.common.util.concurrent.ListenableFuture
 import com.example.socialbatterymanager.shared.preferences.PreferencesManager
+import com.google.common.util.concurrent.ListenableFuture
 import kotlinx.coroutines.flow.first
 import java.util.concurrent.TimeUnit
 
 /**
  * Manager class for handling sync operations
  */
-class SyncManager(private val context: Context) {
-    
-    private val workManager = WorkManager.getInstance(context)
-    private val preferencesManager = PreferencesManager(context)
+class SyncManager(
+    private val context: Context,
+    private val workManager: WorkManager = WorkManager.getInstance(context),
+    private val preferencesManager: PreferencesManager = PreferencesManager(context),
+) {
     
     companion object {
         private const val SYNC_WORK_NAME = "social_battery_sync"

--- a/app/src/test/java/com/example/socialbatterymanager/data/repository/ActivityRepositoryTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/data/repository/ActivityRepositoryTest.kt
@@ -1,0 +1,73 @@
+package com.example.socialbatterymanager.data.repository
+
+import com.example.socialbatterymanager.data.database.ActivityDao
+import com.example.socialbatterymanager.data.model.ActivityEntity
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+class ActivityRepositoryTest {
+
+    private val dao = mockk<ActivityDao>(relaxed = true)
+    private val auditRepo = mockk<AuditRepository>(relaxed = true)
+    private val repository = ActivityRepository(dao, auditRepo)
+
+    @Test
+    fun insertActivity_insertsAndLogs() = runBlocking {
+        val entity = ActivityEntity(
+            id = 1,
+            name = "Test",
+            type = "Type",
+            energy = 5,
+            people = "Solo",
+            mood = "Good",
+            notes = "",
+            date = 0L,
+        )
+
+        repository.insertActivity(entity)
+
+        coVerify { dao.insertActivity(any()) }
+        coVerify {
+            auditRepo.logAuditEntry(
+                entityType = "activity",
+                entityId = entity.id.toString(),
+                action = "create",
+                newValues = any(),
+                userId = null,
+            )
+        }
+    }
+
+    @Test
+    fun deleteActivity_softDeletesAndLogs() = runBlocking {
+        val entity = ActivityEntity(
+            id = 2,
+            name = "ToDelete",
+            type = "Type",
+            energy = 3,
+            people = "Solo",
+            mood = "Ok",
+            notes = "",
+            date = 0L,
+        )
+
+        coEvery { dao.getActivityById(entity.id) } returns entity
+
+        repository.deleteActivity(entity.id)
+
+        coVerify { dao.softDeleteActivity(entity.id) }
+        coVerify {
+            auditRepo.logAuditEntry(
+                entityType = "activity",
+                entityId = entity.id.toString(),
+                action = "delete",
+                oldValues = entity,
+                userId = null,
+            )
+        }
+    }
+}
+

--- a/app/src/test/java/com/example/socialbatterymanager/shared/preferences/PreferencesManagerWriteTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/shared/preferences/PreferencesManagerWriteTest.kt
@@ -1,0 +1,24 @@
+package com.example.socialbatterymanager.shared.preferences
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import java.io.File
+
+class PreferencesManagerWriteTest {
+
+    @Test
+    fun setSyncEnabled_updatesFlow() = runTest {
+        val file = File.createTempFile("test", "prefs")
+        val dataStore = PreferenceDataStoreFactory.create(scope = this) { file }
+        val manager = PreferencesManager(dataStore)
+
+        manager.setSyncEnabled(false)
+
+        assertFalse(manager.syncEnabledFlow.first())
+        file.delete()
+    }
+}
+

--- a/app/src/test/java/com/example/socialbatterymanager/sync/SyncManagerTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/sync/SyncManagerTest.kt
@@ -1,0 +1,49 @@
+package com.example.socialbatterymanager.sync
+
+import android.content.Context
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.WorkManager
+import com.example.socialbatterymanager.shared.preferences.PreferencesManager
+import io.mockk.every
+import io.mockk.verify
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+class SyncManagerTest {
+
+    private val context = mockk<Context>(relaxed = true)
+    private val workManager = mockk<WorkManager>(relaxed = true)
+    private val preferences = mockk<PreferencesManager>()
+
+    @Test
+    fun schedulePeriodicSync_enqueuesWhenEnabled() = runBlocking {
+        every { preferences.syncEnabledFlow } returns flowOf(true)
+        val manager = SyncManager(context, workManager, preferences)
+
+        manager.schedulePeriodicSync()
+
+        verify { workManager.enqueueUniquePeriodicWork(any(), ExistingPeriodicWorkPolicy.KEEP, any()) }
+    }
+
+    @Test
+    fun schedulePeriodicSync_cancelsWhenDisabled() = runBlocking {
+        every { preferences.syncEnabledFlow } returns flowOf(false)
+        val manager = SyncManager(context, workManager, preferences)
+
+        manager.schedulePeriodicSync()
+
+        verify { workManager.cancelUniqueWork(any()) }
+    }
+
+    @Test
+    fun forceSyncNow_enqueuesWork() {
+        val manager = SyncManager(context, workManager, preferences)
+
+        manager.forceSyncNow()
+
+        verify { workManager.enqueue(any()) }
+    }
+}
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -79,6 +79,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 core-testing = { group = "androidx.arch.core", name = "core-testing", version.ref = "core-testing" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines-test" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 androidx-test-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-junit" }
 androidx-test-espresso = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidx-test-espresso" }


### PR DESCRIPTION
## Summary
- add unit tests for ActivityRepository, SyncManager, and PreferencesManager
- create instrumentation tests for repository, sync, and preference logic
- enable JaCoCo coverage check in CI workflow

## Testing
- `./gradlew test` *(fails: In version catalog libs, you can only call the 'from' method a single time)*
- `./gradlew connectedCheck` *(fails: In version catalog libs, you can only call the 'from' method a single time)*

------
https://chatgpt.com/codex/tasks/task_e_6894dd62b93c8324a0915fe8d1170697