### PR TITLE
refactor: centralize version catalog

### DIFF
--- a/requirements-processor/settings.gradle.kts
+++ b/requirements-processor/settings.gradle.kts
@@ -6,11 +6,3 @@ pluginManagement {
 }
 
 rootProject.name = "requirements-processor"
-
-dependencyResolutionManagement {
-    versionCatalogs {
-        create("processorLibs") {
-            from(files("../gradle/libs.versions.toml"))
-        }
-    }
-}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,9 +16,7 @@ dependencyResolutionManagement {
         maven { url = uri("https://jitpack.io") }
     }
     versionCatalogs {
-        create("libs") {
-            from(files("gradle/libs.versions.toml"))
-        }
+        create("libs")
     }
 }
 


### PR DESCRIPTION
## Summary
- use single version catalog loaded in root settings
- drop redundant catalog in requirements-processor module

## Testing
- `./gradlew test` *(fails: Plugin [id: 'com.android.application', version: '8.12.0', apply: false] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894e4d4bae483249a76ddf2e162ba3e