### PR TITLE
Align Kotlin and AGP versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-    id("com.android.application") version "8.12.0" apply false
+    id("com.android.application") version "8.1.2" apply false
     id("org.jetbrains.kotlin.android") version "2.2.0" apply false
     id("org.jetbrains.kotlin.jvm") version "2.2.0" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.0.0" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.2.0" apply false
 }
 
 buildscript {

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,4 +27,4 @@ android.nonFinalResIds=false
 # Allow Gradle to download required Android SDK components so local.properties is not necessary
 android.experimental.sdkDownload=true
 
-kotlin.version=1.9.23
+kotlin.version=2.2.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,7 +49,7 @@ firebase-bom = "34.0.0"
 google-services = "4.4.3"
 firebase-crashlytics-gradle = "3.0.5"
 hilt-android-gradle-plugin = "2.57"
-ksp = "1.9.0"
+ksp = "2.0.0-1.0.24"
 hilt-work = "1.2.0"
 
 [libraries]
@@ -111,5 +111,5 @@ androidx-hilt-compiler = { group = "androidx.hilt", name = "hilt-compiler", vers
 
 [plugins]
 googleServices = "com.google.gms.google-services:4.4.3"
-firebaseCrashlyticsGradle = "com.google.firebase.crashlytics:2.9.9"
-hiltAndroidGradlePlugin = "com.google.dagger.hilt.android:2.47"
+firebaseCrashlyticsGradle = "com.google.firebase.crashlytics:3.0.5"
+hiltAndroidGradlePlugin = "com.google.dagger.hilt.android:2.57"


### PR DESCRIPTION
## Summary
- switch AGP to stable 8.1.2 and match Compose plugin with Kotlin 2.2.0
- set `kotlin.version` property to 2.2.0
- synchronize plugin versions for Hilt, KSP and Crashlytics

## Testing
- `./gradlew help` *(fails: Plugin [id: 'com.android.application', version: '8.1.2'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894e91106408324a45684544abea43a