### PR TITLE
Use stable SDK level 34

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,12 +27,12 @@ android {
     }
 
     namespace = "com.example.socialbatterymanager"
-    compileSdk = 36
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.example.socialbatterymanager"
         minSdk = 24
-        targetSdk = 36
+        targetSdk = 34
         versionCode = 2
         versionName = "1.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
## Summary
- update app module to compile and target SDK 34

## Testing
- `./gradlew help --refresh-dependencies` *(fails: Plugin [id: 'com.android.application', version: '8.12.0', apply: false] was not found)*
- `./gradlew test` *(fails: Plugin [id: 'com.google.devtools.ksp', version: '1.9.0'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894e911be9083249af723f425c552a0