### PR TITLE
Use Robolectric for unit tests

### DIFF
--- a/app/src/test/java/com/example/socialbatterymanager/data/repository/ImportExportManagerTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/data/repository/ImportExportManagerTest.kt
@@ -2,7 +2,7 @@ package com.example.socialbatterymanager.data.repository
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.robolectric.RobolectricTestRunner
 import com.example.socialbatterymanager.data.model.ActivityEntity
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -21,7 +21,7 @@ import org.junit.runner.RunWith
 import java.io.File
 import java.io.FileWriter
 
-@RunWith(AndroidJUnit4::class)
+@RunWith(RobolectricTestRunner::class)
 class ImportExportManagerTest {
 
     @Test

--- a/app/src/test/java/com/example/socialbatterymanager/data/repository/SecurityManagerTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/data/repository/SecurityManagerTest.kt
@@ -1,7 +1,7 @@
 package com.example.socialbatterymanager.data.repository
 
 import android.content.SharedPreferences
-import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.robolectric.RobolectricTestRunner
 import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -9,7 +9,7 @@ import org.robolectric.RuntimeEnvironment
 import java.io.File
 import java.util.Base64
 
-@RunWith(AndroidJUnit4::class)
+@RunWith(RobolectricTestRunner::class)
 class SecurityManagerTest {
 
     @Test

--- a/app/src/test/java/com/example/socialbatterymanager/features/home/SimpleHomeFragmentTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/features/home/SimpleHomeFragmentTest.kt
@@ -7,7 +7,7 @@ import android.widget.TextView
 import androidx.navigation.NavController
 import androidx.navigation.Navigation
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.robolectric.RobolectricTestRunner
 import com.example.socialbatterymanager.R
 import com.example.socialbatterymanager.features.home.ui.SimpleHomeFragment
 import com.example.socialbatterymanager.features.notifications.NotificationService
@@ -22,7 +22,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 
-@RunWith(AndroidJUnit4::class)
+@RunWith(RobolectricTestRunner::class)
 class SimpleHomeFragmentTest {
 
     @Test

--- a/app/src/test/java/com/example/socialbatterymanager/features/notifications/NotificationServiceTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/features/notifications/NotificationServiceTest.kt
@@ -1,7 +1,7 @@
 package com.example.socialbatterymanager.features.notifications
 
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.robolectric.RobolectricTestRunner
 import com.example.socialbatterymanager.data.database.AppDatabase
 import com.example.socialbatterymanager.data.database.NotificationDao
 import com.example.socialbatterymanager.shared.preferences.PreferencesManager
@@ -20,7 +20,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import androidx.room.Room
 
-@RunWith(AndroidJUnit4::class)
+@RunWith(RobolectricTestRunner::class)
 class NotificationServiceTest {
     private lateinit var database: AppDatabase
     private lateinit var dao: NotificationDao

--- a/app/src/test/java/com/example/socialbatterymanager/notification/EnergyReminderWorkerTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/notification/EnergyReminderWorkerTest.kt
@@ -7,6 +7,8 @@ import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
 import androidx.work.WorkerFactory
 import androidx.work.testing.TestListenableWorkerBuilder
+import androidx.work.Configuration
+import androidx.work.testing.WorkManagerTestInitHelper
 import com.example.socialbatterymanager.data.database.AppDatabase
 import com.example.socialbatterymanager.data.database.EnergyLogDao
 import com.example.socialbatterymanager.data.model.EnergyLog
@@ -19,12 +21,17 @@ import io.mockk.verify
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class EnergyReminderWorkerTest {
 
     @Test
     fun doesNotShowNotificationWhenDisabled() = runTest {
         val context = spyk(ApplicationProvider.getApplicationContext<Context>())
+        val config = Configuration.Builder().build()
+        WorkManagerTestInitHelper.initializeTestWorkManager(context, config)
         val notificationManager = mockk<NotificationManager>(relaxed = true)
         every { context.getSystemService(Context.NOTIFICATION_SERVICE) } returns notificationManager
 

--- a/app/src/test/java/com/example/socialbatterymanager/profile/ProfileTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/profile/ProfileTest.kt
@@ -1,14 +1,12 @@
 package com.example.socialbatterymanager.profile
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.robolectric.RobolectricTestRunner
 import com.example.socialbatterymanager.data.model.User
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.Assert.*
 
-@RunWith(AndroidJUnit4::class)
+@RunWith(RobolectricTestRunner::class)
 class ProfileTest {
 
     @Test


### PR DESCRIPTION
## Summary
- Replace AndroidJUnit4 runner with RobolectricTestRunner in unit tests
- Annotate EnergyReminderWorkerTest with RobolectricTestRunner and initialize WorkManager test environment

## Testing
- `./gradlew testDebugUnitTest` *(fails: Plugin [id: 'com.google.devtools.ksp', version: '1.9.0'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894e914a33c83249879cb671459ba43