### PR TITLE
Document release signing strategy

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -39,10 +39,33 @@ jobs:
       - name: Run static analysis and unit tests
         run: ./gradlew ktlintCheck detekt jacocoTestCoverageVerification
 
+      - name: Prepare release keystore
+        env:
+          RELEASE_STORE_FILE: ${{ secrets.RELEASE_STORE_FILE }}
+          RELEASE_STORE_PASSWORD: ${{ secrets.RELEASE_STORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: |
+          echo "$RELEASE_STORE_FILE" | base64 --decode > release.keystore
+          echo "RELEASE_STORE_FILE=$PWD/release.keystore" >> $GITHUB_ENV
+          echo "RELEASE_STORE_PASSWORD=$RELEASE_STORE_PASSWORD" >> $GITHUB_ENV
+          echo "RELEASE_KEY_ALIAS=$RELEASE_KEY_ALIAS" >> $GITHUB_ENV
+          echo "RELEASE_KEY_PASSWORD=$RELEASE_KEY_PASSWORD" >> $GITHUB_ENV
+
+      - name: Assemble release APK
+        run: ./gradlew assembleRelease
+
       - name: Assemble debug APK
         run: ./gradlew assembleDebug
 
-      - name: Upload APK artifact
+      - name: Upload release APK artifact
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release
+          path: app/build/outputs/apk/release/app-release.apk
+
+      - name: Upload debug APK artifact
         if: success()
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# SocialBatteryManager
+
+SocialBatteryManager is an Android application for managing your social energy.
+
+## Release Signing
+
+This project uses a private keystore to self‑sign release builds. The signing
+keystore and its credentials are stored as CI secrets and supplied at build
+time. GitHub Actions decodes the base64‑encoded keystore and exports the
+following variables before running `assembleRelease`:
+
+- `RELEASE_STORE_FILE`
+- `RELEASE_STORE_PASSWORD`
+- `RELEASE_KEY_ALIAS`
+- `RELEASE_KEY_PASSWORD`
+
+For local release builds, set the same variables in your environment:
+
+```bash
+export RELEASE_STORE_FILE=/absolute/path/to/release.keystore
+export RELEASE_STORE_PASSWORD=yourStorePassword
+export RELEASE_KEY_ALIAS=yourKeyAlias
+export RELEASE_KEY_PASSWORD=yourKeyPassword
+./gradlew assembleRelease
+```
+
+The keystore file itself is **not** checked into the repository. Ensure the
+secrets remain private and rotate them if the keystore is ever compromised.


### PR DESCRIPTION
## Summary
- configure CI workflow to decode release keystore from secrets and assemble release
- add repository README explaining self-signed release process with required environment variables

## Testing
- `./gradlew ktlintCheck detekt jacocoTestCoverageVerification` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68bc28efb62c83249436fe722d5162b8