### PR TITLE
Use Hilt for PreferencesManager and SyncManager

### DIFF
--- a/app/src/androidTest/java/com/example/socialbatterymanager/sync/SyncManagerInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/example/socialbatterymanager/sync/SyncManagerInstrumentedTest.kt
@@ -1,7 +1,5 @@
 package com.example.socialbatterymanager.sync
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.WorkManager
 import com.example.socialbatterymanager.shared.preferences.PreferencesManager
@@ -13,13 +11,12 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class SyncManagerInstrumentedTest {
 
-    private val context: Context = ApplicationProvider.getApplicationContext()
     private val workManager = mockk<WorkManager>(relaxed = true)
     private val prefs = mockk<PreferencesManager>(relaxed = true)
 
     @Test
     fun forceSyncNow_enqueuesWork() {
-        val manager = SyncManager(context, workManager, prefs)
+        val manager = SyncManager(workManager, prefs)
 
         manager.forceSyncNow()
 

--- a/app/src/main/java/com/example/socialbatterymanager/MainActivity.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.navigation.ui.setupWithNavController
 import com.example.socialbatterymanager.BuildConfig
 import com.example.socialbatterymanager.shared.preferences.PreferencesManager
 import com.example.socialbatterymanager.sync.SyncManager
+import javax.inject.Inject
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import dagger.hilt.android.AndroidEntryPoint
@@ -26,8 +27,10 @@ import java.io.IOException
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
 
-    private lateinit var preferencesManager: PreferencesManager
-    private lateinit var syncManager: SyncManager
+    @Inject
+    lateinit var preferencesManager: PreferencesManager
+    @Inject
+    lateinit var syncManager: SyncManager
     private lateinit var bottomNavigationView: BottomNavigationView
 
     private val notificationPermissionLauncher = registerForActivityResult(
@@ -39,9 +42,6 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         
-        preferencesManager = PreferencesManager(this)
-        syncManager = SyncManager(this)
-
         // Show a splash screen while preferences load
         setContentView(R.layout.activity_splash)
 

--- a/app/src/main/java/com/example/socialbatterymanager/di/AppModule.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/di/AppModule.kt
@@ -3,7 +3,6 @@ package com.example.socialbatterymanager.di
 import android.content.Context
 import com.example.socialbatterymanager.data.database.AppDatabase
 import com.example.socialbatterymanager.data.repository.SecurityManager
-import com.example.socialbatterymanager.shared.preferences.PreferencesManager
 import com.google.gson.Gson
 import dagger.Module
 import dagger.Provides
@@ -39,8 +38,4 @@ class AppModule {
     @Singleton
     fun provideGson(): Gson = Gson()
 
-    @Provides
-    @Singleton
-    fun providePreferencesManager(@ApplicationContext context: Context): PreferencesManager =
-        PreferencesManager(context)
 }

--- a/app/src/main/java/com/example/socialbatterymanager/shared/preferences/PreferencesModule.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/shared/preferences/PreferencesModule.kt
@@ -1,0 +1,18 @@
+package com.example.socialbatterymanager.shared.preferences
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object PreferencesModule {
+    @Provides
+    @Singleton
+    fun providePreferencesManager(@ApplicationContext context: Context): PreferencesManager =
+        PreferencesManager(context)
+}

--- a/app/src/main/java/com/example/socialbatterymanager/sync/SyncManager.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/sync/SyncManager.kt
@@ -1,6 +1,5 @@
 package com.example.socialbatterymanager.sync
 
-import android.content.Context
 import androidx.concurrent.futures.CallbackToFutureAdapter
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
@@ -12,14 +11,14 @@ import com.example.socialbatterymanager.shared.preferences.PreferencesManager
 import com.google.common.util.concurrent.ListenableFuture
 import kotlinx.coroutines.flow.first
 import java.util.concurrent.TimeUnit
+import javax.inject.Inject
 
 /**
  * Manager class for handling sync operations
  */
-class SyncManager(
-    private val context: Context,
-    private val workManager: WorkManager = WorkManager.getInstance(context),
-    private val preferencesManager: PreferencesManager = PreferencesManager(context),
+class SyncManager @Inject constructor(
+    private val workManager: WorkManager,
+    private val preferencesManager: PreferencesManager,
 ) {
     
     companion object {

--- a/app/src/main/java/com/example/socialbatterymanager/sync/SyncModule.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/sync/SyncModule.kt
@@ -1,0 +1,27 @@
+package com.example.socialbatterymanager.sync
+
+import android.content.Context
+import androidx.work.WorkManager
+import com.example.socialbatterymanager.shared.preferences.PreferencesManager
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object SyncModule {
+    @Provides
+    @Singleton
+    fun provideWorkManager(@ApplicationContext context: Context): WorkManager =
+        WorkManager.getInstance(context)
+
+    @Provides
+    @Singleton
+    fun provideSyncManager(
+        workManager: WorkManager,
+        preferencesManager: PreferencesManager
+    ): SyncManager = SyncManager(workManager, preferencesManager)
+}

--- a/app/src/test/java/com/example/socialbatterymanager/sync/SyncManagerTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/sync/SyncManagerTest.kt
@@ -1,6 +1,5 @@
 package com.example.socialbatterymanager.sync
 
-import android.content.Context
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.WorkManager
 import com.example.socialbatterymanager.shared.preferences.PreferencesManager
@@ -13,14 +12,13 @@ import org.junit.Test
 
 class SyncManagerTest {
 
-    private val context = mockk<Context>(relaxed = true)
     private val workManager = mockk<WorkManager>(relaxed = true)
     private val preferences = mockk<PreferencesManager>()
 
     @Test
     fun schedulePeriodicSync_enqueuesWhenEnabled() = runBlocking {
         every { preferences.syncEnabledFlow } returns flowOf(true)
-        val manager = SyncManager(context, workManager, preferences)
+        val manager = SyncManager(workManager, preferences)
 
         manager.schedulePeriodicSync()
 
@@ -30,7 +28,7 @@ class SyncManagerTest {
     @Test
     fun schedulePeriodicSync_cancelsWhenDisabled() = runBlocking {
         every { preferences.syncEnabledFlow } returns flowOf(false)
-        val manager = SyncManager(context, workManager, preferences)
+        val manager = SyncManager(workManager, preferences)
 
         manager.schedulePeriodicSync()
 
@@ -39,7 +37,7 @@ class SyncManagerTest {
 
     @Test
     fun forceSyncNow_enqueuesWork() {
-        val manager = SyncManager(context, workManager, preferences)
+        val manager = SyncManager(workManager, preferences)
 
         manager.forceSyncNow()
 


### PR DESCRIPTION
## Summary
- provide a dedicated `PreferencesModule` for a singleton `PreferencesManager`
- add `SyncModule` supplying `WorkManager` and the now `@Inject`-annotated `SyncManager`
- inject `PreferencesManager` and `SyncManager` directly into `MainActivity`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2fd72f6c8324bd4f23105b7e6096