### PR TITLE
Handle migration failures and invalid database passphrases

### DIFF
--- a/app/src/main/java/com/example/socialbatterymanager/data/database/AppDatabase.kt
+++ b/app/src/main/java/com/example/socialbatterymanager/data/database/AppDatabase.kt
@@ -190,7 +190,23 @@ abstract class AppDatabase : RoomDatabase() {
                 MIGRATION_5_6,
                 MIGRATION_6_7
             )
-            return builder.build()
+                .fallbackToDestructiveMigration()
+
+            val db = builder.build()
+
+            if (passphrase != null) {
+                try {
+                    db.openHelper.writableDatabase
+                } catch (e: Exception) {
+                    android.util.Log.e(
+                        "AppDatabase",
+                        "Invalid database passphrase provided",
+                        e
+                    )
+                    throw IllegalStateException("Invalid database passphrase", e)
+                }
+            }
+            return db
         }
 
         fun clearInstance() {

--- a/app/src/test/java/com/example/socialbatterymanager/data/database/AppDatabaseTest.kt
+++ b/app/src/test/java/com/example/socialbatterymanager/data/database/AppDatabaseTest.kt
@@ -1,0 +1,49 @@
+package com.example.socialbatterymanager.data.database
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AppDatabaseTest {
+
+    @Test
+    fun getDatabase_withHigherVersion_fallbackDestructiveMigration() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val dbFile = context.getDatabasePath("social_battery_db")
+        if (dbFile.exists()) dbFile.delete()
+
+        val sqlite = SQLiteDatabase.openOrCreateDatabase(dbFile, null)
+        sqlite.version = 99
+        sqlite.close()
+
+        AppDatabase.clearInstance()
+        val db = AppDatabase.getDatabase(context)
+        val version = db.openHelper.writableDatabase.version
+        assertEquals(7, version)
+        db.close()
+    }
+
+    @Test
+    fun getDatabase_invalidPassphrase_throws() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val dbFile = context.getDatabasePath("social_battery_db")
+        if (dbFile.exists()) dbFile.delete()
+
+        val passphrase = "correct"
+        AppDatabase.clearInstance()
+        val db = AppDatabase.getDatabase(context, passphrase)
+        db.close()
+        AppDatabase.clearInstance()
+
+        assertThrows(IllegalStateException::class.java) {
+            AppDatabase.getDatabase(context, "wrong")
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Ensure Room database falls back to destructive migration when normal migrations fail
- Detect and surface invalid database passphrases
- Add tests covering migration fallback and passphrase handling

## Testing
- `./gradlew testDebugUnitTest` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68bc2fda53608324800931648422b432